### PR TITLE
Add support for orphan datasets

### DIFF
--- a/src/components/DataTable/CustomCell.tsx
+++ b/src/components/DataTable/CustomCell.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Table } from '@devexpress/dx-react-grid-material-ui';
 import { Chip as MuiChip } from '@material-ui/core';
 
+import { useProjects } from '../../hooks';
 import { Dataset } from '../../Services/apiTypes';
 import DeleteButton from './DeleteButton';
 import DownloadButton from './DownloadButton';
@@ -13,6 +14,7 @@ import EditButton from './EditButton';
 enum ColumnTypes {
   ACTIONS = 'actions',
   LABELS = 'labels',
+  PROJECTS = 'projects',
 }
 
 type IProps = Omit<Table.DataCellProps, 'row'> & {
@@ -23,6 +25,7 @@ type IProps = Omit<Table.DataCellProps, 'row'> & {
  * Display rich content based on column name
  */
 const CustomCell: React.FC<IProps> = ({ row, column, ...rest }) => {
+  const { projects } = useProjects();
   switch (column.name) {
     case ColumnTypes.ACTIONS:
       return (
@@ -38,6 +41,15 @@ const CustomCell: React.FC<IProps> = ({ row, column, ...rest }) => {
           {row.labels.map((label, index) => (
             <Chip key={index} label={label} />
           ))}
+        </Cell>
+      );
+    case ColumnTypes.PROJECTS:
+      return (
+        <Cell row={row} column={column} {...rest}>
+          {row.projects.map((projectId) => {
+            const name = projects.find((project) => project.projectId === projectId)?.name;
+            return <Chip key={projectId} label={name} />;
+          })}
         </Cell>
       );
     default:

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -33,7 +33,7 @@ type Column = { name: keyof ColumnTypes; title: string };
 
 const columns: Column[] = [
   { name: 'name', title: 'File Name' },
-  // { name: 'projects', title: 'Projects' },
+  { name: 'projects', title: 'Projects' },
   { name: 'labels', title: 'Labels' },
   { name: 'actions', title: 'Actions' },
 ];

--- a/src/context/datasets.tsx
+++ b/src/context/datasets.tsx
@@ -26,14 +26,15 @@ export const DatasetsProvider: React.FC<IProps> = ({ children, project }) => {
   const projectId = project?.projectId;
 
   const refreshDatasets = useCallback(async () => {
+    setLoading(true);
     if (projectId !== undefined) {
-      setLoading(true);
       const newDatasets = await DataTierAPI.getDatasetsFromProject(projectId);
       setDatasets(newDatasets);
-      setLoading(false);
     } else {
-      setDatasets([]);
+      const newDatasets = await DataTierAPI.getOwnedDatasets();
+      setDatasets(newDatasets);
     }
+    setLoading(false);
   }, [projectId]);
 
   useEffect(() => {


### PR DESCRIPTION
When the project selector is empty, all your own datasets will be displayed. This also adds a projects column to the table. 

Currently, this breaks when a project is selected since the API has the available projects missing in the response. 
Waiting on the api to change to have projects on project/dataset endpoint.