### PR TITLE
Update to typescript 4.5

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,14 +62,7 @@
     "@typescript-eslint/no-unnecessary-condition": "warn",
     "@typescript-eslint/no-unnecessary-type-assertion": "warn",
     "@typescript-eslint/no-unnecessary-type-constraint": "warn",
-    "@typescript-eslint/no-unused-vars": [
-      "warn",
-      {
-        "args": "none",
-        "ignoreRestSiblings": true,
-        "argsIgnorePattern": "^_"
-      }
-    ],
+    "@typescript-eslint/no-unused-vars": 0,
     "no-console": 0,
     "prettier/prettier": [
       "warn",
@@ -87,14 +80,15 @@
       "error",
       {
         "groups": [
-          // Node.js builtins. You could also generate this regex if you use a `.js` config.
-          // For example: `^(${require("module").builtinModules.join("|")})(/|$)`
           [
             "^(assert|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|https|module|net|os|path|punycode|querystring|readline|repl|stream|string_decoder|sys|timers|tls|tty|url|util|vm|zlib|freelist|v8|process|async_hooks|http2|perf_hooks)(/.*|$)"
           ],
-          // Packages. `react` related packages come first.
+          // React comes first
           [
             "^react"
+          ],
+          [
+            "^\\u0000"
           ],
           // Internal packages.
           [
@@ -104,9 +98,6 @@
             "^@?\\w"
           ],
           // Side effect imports.
-          [
-            "^\\u0000"
-          ],
           // Parent imports. Put `..` last.
           // Other relative imports. Put same-folder imports and `.` last.
           [

--- a/.vscode/components.code-snippets
+++ b/.vscode/components.code-snippets
@@ -1,0 +1,40 @@
+{
+	"childcomp": {
+		"prefix": "childcomp",
+		"description": "React functional component with FC component type and props interface",
+		"body": [
+			"import type { FC } from 'react';",
+			"",
+			"export interface ${TM_FILENAME_BASE}Props {",
+			"  $1",
+			"}",
+			"",
+			"export const ${TM_FILENAME_BASE}: FC<${TM_FILENAME_BASE}Props> = ({ $2 }) => {",
+			"  return (",
+			"    <>",
+			"      $3",
+			"    </>",
+			"  );",
+			"};",
+			""
+		]
+	},
+	"comp": {
+		"prefix": "comp",
+		"description": "React functional component with props",
+		"body": [
+			"export interface ${TM_FILENAME_BASE}Props {",
+			"  $1",
+			"}",
+			"",
+			"export const ${TM_FILENAME_BASE} = ({ $2 }: ${TM_FILENAME_BASE}Props) => {",
+			"  return (",
+			"    <>",
+			"      $3",
+			"    </>",
+			"  );",
+			"};",
+			""
+		]
+	}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -143,6 +143,7 @@
     "instance-page",
     "project-details",
     "ui/user-settings",
-    "ui/plain-text-viewer"
+    "ui/plain-text-viewer",
+    "jsx-transform"
   ],
 }

--- a/components/BaseCard.tsx
+++ b/components/BaseCard.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import {

--- a/components/CenterLoader.tsx
+++ b/components/CenterLoader.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { css } from '@emotion/react';
 import { CircularProgress } from '@material-ui/core';
 

--- a/components/Chips.tsx
+++ b/components/Chips.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import React from 'react';
 
 import { css } from '@emotion/react';
 import { useTheme } from '@material-ui/core';

--- a/components/DataTable/DataTable.tsx
+++ b/components/DataTable/DataTable.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
-import React from 'react';
 import type {
   Cell,
   CellProps,

--- a/components/DataTable/IndeterminateCheckbox.tsx
+++ b/components/DataTable/IndeterminateCheckbox.tsx
@@ -1,5 +1,6 @@
 import type { MutableRefObject } from 'react';
-import React, { forwardRef, useEffect } from 'react';
+import { useRef } from 'react';
+import { forwardRef, useEffect } from 'react';
 
 import type { CheckboxProps } from '@material-ui/core';
 import { Checkbox } from '@material-ui/core';
@@ -10,7 +11,7 @@ import { Checkbox } from '@material-ui/core';
  */
 export const IndeterminateCheckbox = forwardRef<HTMLInputElement, CheckboxProps>(
   ({ indeterminate, ...rest }, ref) => {
-    const defaultRef = React.useRef();
+    const defaultRef = useRef();
     const resolvedRef = (ref || defaultRef) as MutableRefObject<HTMLButtonElement>;
 
     useEffect(() => {

--- a/components/DatasetsTable/DatasetDetails/DatasetDetails.tsx
+++ b/components/DatasetsTable/DatasetDetails/DatasetDetails.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
 import { useLayoutEffect } from 'react';
 import { useState } from 'react';
-import React from 'react';
 
 import type { DatasetSummary, DatasetVersionSummary } from '@squonk/data-manager-client';
 

--- a/components/DatasetsTable/DatasetDetails/ManageDatasetEditorsSection/ManageDatasetEditorsSection.tsx
+++ b/components/DatasetsTable/DatasetDetails/ManageDatasetEditorsSection/ManageDatasetEditorsSection.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { DatasetSummary } from '@squonk/data-manager-client';

--- a/components/DatasetsTable/DatasetDetails/ManageDatasetEditorsSection/ManageEditors.tsx
+++ b/components/DatasetsTable/DatasetDetails/ManageDatasetEditorsSection/ManageEditors.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import React from 'react';
 
 import { useGetUsers } from '@squonk/data-manager-client/user';
 

--- a/components/DatasetsTable/DatasetDetails/NewVersionListItem.tsx
+++ b/components/DatasetsTable/DatasetDetails/NewVersionListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { DatasetSummary } from '@squonk/data-manager-client';

--- a/components/DatasetsTable/DatasetDetails/VersionActionsSection/AttachDatasetListItem/AttachDatasetListItem.tsx
+++ b/components/DatasetsTable/DatasetDetails/VersionActionsSection/AttachDatasetListItem/AttachDatasetListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { DatasetVersionSummary, Error as DMError } from '@squonk/data-manager-client';

--- a/components/DatasetsTable/DatasetDetails/VersionActionsSection/DatasetSchemaListItem/DatasetSchemaListItem.tsx
+++ b/components/DatasetsTable/DatasetDetails/VersionActionsSection/DatasetSchemaListItem/DatasetSchemaListItem.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import React from 'react';
 
 import { ListItem, ListItemText } from '@material-ui/core';
 import FindInPageRoundedIcon from '@material-ui/icons/FindInPageRounded';

--- a/components/DatasetsTable/DatasetDetails/VersionActionsSection/DatasetSchemaListItem/DatasetSchemaViewModal/DatasetSchemaViewModal.tsx
+++ b/components/DatasetsTable/DatasetDetails/VersionActionsSection/DatasetSchemaListItem/DatasetSchemaViewModal/DatasetSchemaViewModal.tsx
@@ -1,6 +1,5 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
-import React from 'react';
 import type { Cell, Column } from 'react-table';
 
 import { Typography } from '@material-ui/core';

--- a/components/DatasetsTable/DatasetDetails/VersionActionsSection/DeleteDatasetListItem.tsx
+++ b/components/DatasetsTable/DatasetDetails/VersionActionsSection/DeleteDatasetListItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { DatasetVersionSummary } from '@squonk/data-manager-client';

--- a/components/DatasetsTable/DatasetsTable.tsx
+++ b/components/DatasetsTable/DatasetsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { Column, Row } from 'react-table';
 
 import type { DatasetsGetResponse, Error as DMError } from '@squonk/data-manager-client';

--- a/components/FileSelector/AllFilesList.tsx
+++ b/components/FileSelector/AllFilesList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { useGetFiles } from '@squonk/data-manager-client/file';
 

--- a/components/FileSelector/FavouritesList.tsx
+++ b/components/FileSelector/FavouritesList.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Typography } from '@material-ui/core';
 import FolderSpecialRoundedIcon from '@material-ui/icons/FolderSpecialRounded';
 

--- a/components/FileSelector/FileListItem.tsx
+++ b/components/FileSelector/FileListItem.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { css } from '@emotion/react';
 import {

--- a/components/FileSelector/FileSelector.tsx
+++ b/components/FileSelector/FileSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import { Box, Button, Collapse } from '@material-ui/core';

--- a/components/FileSelector/MiniFileList.tsx
+++ b/components/FileSelector/MiniFileList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Box, Checkbox, FormControlLabel } from '@material-ui/core';
 

--- a/components/FileSelector/PathBreadcrumbs.tsx
+++ b/components/FileSelector/PathBreadcrumbs.tsx
@@ -1,5 +1,4 @@
 import type { Dispatch, SetStateAction } from 'react';
-import React from 'react';
 
 import { Breadcrumbs, Link, Typography } from '@material-ui/core';
 

--- a/components/FileSelector/SelectedFilesLabel.tsx
+++ b/components/FileSelector/SelectedFilesLabel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { css } from '@emotion/react';
 import { Tooltip, Typography } from '@material-ui/core';
 

--- a/components/FileUpload/BulkUploadDropzone.tsx
+++ b/components/FileUpload/BulkUploadDropzone.tsx
@@ -1,5 +1,4 @@
 import type { Dispatch, SetStateAction } from 'react';
-import React from 'react';
 
 import { Grid } from '@material-ui/core';
 

--- a/components/FileUpload/FileUpload.tsx
+++ b/components/FileUpload/FileUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import type { DatasetPostBodyBody, Error as DMError } from '@squonk/data-manager-client';
 import { uploadDataset } from '@squonk/data-manager-client/dataset';

--- a/components/FileUpload/SingleFileUploader.tsx
+++ b/components/FileUpload/SingleFileUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type { FileError } from 'react-dropzone';
 import { useQueryClient } from 'react-query';
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { AppBar, Toolbar } from '@material-ui/core';
 
 import { Logo } from './navigation/Logo';

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import React from 'react';
 
 import { Box } from '@material-ui/core';
 

--- a/components/LocalTime/LocalTime.tsx
+++ b/components/LocalTime/LocalTime.tsx
@@ -1,5 +1,4 @@
 import type { HTMLProps } from 'react';
-import React from 'react';
 
 import { toLocalTimeString } from './utils';
 

--- a/components/ProjectManager/AddProject.tsx
+++ b/components/ProjectManager/AddProject.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import {

--- a/components/ProjectManager/EditProject.tsx
+++ b/components/ProjectManager/EditProject.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { IconButton, Tooltip, Typography } from '@material-ui/core';
 import EditIcon from '@material-ui/icons/Edit';

--- a/components/ProjectManager/ProjectEditors.tsx
+++ b/components/ProjectManager/ProjectEditors.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import {

--- a/components/ProjectManager/ProjectManager.tsx
+++ b/components/ProjectManager/ProjectManager.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import {

--- a/components/ProjectTable/Buttons/CreateDatasetFromFileButton.tsx
+++ b/components/ProjectTable/Buttons/CreateDatasetFromFileButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import {

--- a/components/ProjectTable/Buttons/DeleteUnmanagedFileButton.tsx
+++ b/components/ProjectTable/Buttons/DeleteUnmanagedFileButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { DeleteUnmanagedFileParams } from '@squonk/data-manager-client';

--- a/components/ProjectTable/Buttons/DetachDataset.tsx
+++ b/components/ProjectTable/Buttons/DetachDataset.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import { getGetFilesQueryKey, useDeleteFile } from '@squonk/data-manager-client/file';

--- a/components/ProjectTable/Buttons/FavouriteButton.tsx
+++ b/components/ProjectTable/Buttons/FavouriteButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { IconButton } from '@material-ui/core';
 import { Tooltip } from '@material-ui/core';
 import StarBorderRoundedIcon from '@material-ui/icons/StarBorderRounded';

--- a/components/ProjectTable/FileActions.tsx
+++ b/components/ProjectTable/FileActions.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useCurrentProjectId } from '../../hooks/currentProjectHooks';
 import { useProjectBreadcrumbs } from '../../hooks/projectPathHooks';
 import { CreateDatasetFromFileButton } from './Buttons/CreateDatasetFromFileButton';

--- a/components/ProjectTable/ProjectTable.tsx
+++ b/components/ProjectTable/ProjectTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { Cell, CellProps, Column, PluginHook } from 'react-table';
 
 import type { ProjectDetail } from '@squonk/data-manager-client';

--- a/components/RoleWarning.tsx
+++ b/components/RoleWarning.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Box } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 

--- a/components/SearchTextField.tsx
+++ b/components/SearchTextField.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { TextFieldProps } from '@material-ui/core';
 import { InputAdornment, TextField } from '@material-ui/core';
 import SearchRoundedIcon from '@material-ui/icons/SearchRounded';

--- a/components/SlideUpTransition.tsx
+++ b/components/SlideUpTransition.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { forwardRef } from 'react';
 
 import type { SlideProps } from '@material-ui/core';
 import { Slide } from '@material-ui/core';
@@ -6,6 +6,6 @@ import { Slide } from '@material-ui/core';
 /**
  * Slide component by locked to the "up" direction
  */
-export const SlideUpTransition = React.forwardRef((props: SlideProps, ref: React.Ref<unknown>) => {
+export const SlideUpTransition = forwardRef((props: SlideProps, ref: React.Ref<unknown>) => {
   return <Slide direction="up" ref={ref} {...props} />;
 });

--- a/components/ThemeProviders.tsx
+++ b/components/ThemeProviders.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import React from 'react';
 
 import { generateThemes } from '@squonk/mui-theme';
 

--- a/components/WarningDeleteButton.tsx
+++ b/components/WarningDeleteButton.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 import { useState } from 'react';
-import React from 'react';
 
 import { Tooltip, Typography } from '@material-ui/core';
 

--- a/components/executionsCards/ApplicationCard/ApplicationCard.tsx
+++ b/components/executionsCards/ApplicationCard/ApplicationCard.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { ApplicationSummary } from '@squonk/data-manager-client';
 
 import { useTheme } from '@material-ui/core';

--- a/components/executionsCards/ApplicationCard/ApplicationModal.tsx
+++ b/components/executionsCards/ApplicationCard/ApplicationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { ApplicationSummary } from '@squonk/data-manager-client';

--- a/components/executionsCards/ApplicationCard/ApplicationModalButton.tsx
+++ b/components/executionsCards/ApplicationCard/ApplicationModalButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Button, Tooltip } from '@material-ui/core';
 

--- a/components/executionsCards/InstancesList.tsx
+++ b/components/executionsCards/InstancesList.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { InstanceSummary } from '@squonk/data-manager-client';
 import { useGetInstances } from '@squonk/data-manager-client/instance';
 

--- a/components/executionsCards/JobCard/JobCard.tsx
+++ b/components/executionsCards/JobCard/JobCard.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { JobSummary } from '@squonk/data-manager-client';
 
 import { Chip, Link, Typography, useTheme } from '@material-ui/core';

--- a/components/executionsCards/JobCard/JobInputFields.tsx
+++ b/components/executionsCards/JobCard/JobInputFields.tsx
@@ -1,5 +1,4 @@
 import type { Dispatch, SetStateAction } from 'react';
-import React from 'react';
 
 import { Grid, Typography } from '@material-ui/core';
 

--- a/components/executionsCards/JobCard/JobModal.tsx
+++ b/components/executionsCards/JobCard/JobModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { InstanceSummary, JobSummary } from '@squonk/data-manager-client';

--- a/components/executionsCards/JobCard/RunJobButton.tsx
+++ b/components/executionsCards/JobCard/RunJobButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Button, Tooltip } from '@material-ui/core';
 

--- a/components/labels/LabelChip.tsx
+++ b/components/labels/LabelChip.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { ChipProps } from '@material-ui/core';
 import { Chip } from '@material-ui/core';
 

--- a/components/labels/Labels.tsx
+++ b/components/labels/Labels.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { DatasetVersionSummary } from '@squonk/data-manager-client';

--- a/components/labels/NewLabelButton.tsx
+++ b/components/labels/NewLabelButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import { getGetDatasetsQueryKey, useAddAnnotations } from '@squonk/data-manager-client/dataset';

--- a/components/modals/FormikModalWrapper.tsx
+++ b/components/modals/FormikModalWrapper.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { css } from '@emotion/react';
 import type { DialogProps } from '@material-ui/core';
 import type { FormikConfig } from 'formik';

--- a/components/modals/ModalWrapper.tsx
+++ b/components/modals/ModalWrapper.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { css } from '@emotion/react';
 import {
   Button,

--- a/components/navigation/MobileNavMenu.tsx
+++ b/components/navigation/MobileNavMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import {

--- a/components/navigation/NavLink.tsx
+++ b/components/navigation/NavLink.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import Link from 'next/link';
 import { useRouter } from 'next/router';

--- a/components/navigation/NavLinks.tsx
+++ b/components/navigation/NavLinks.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';

--- a/components/navigation/ProjectModalButton.tsx
+++ b/components/navigation/ProjectModalButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { IconButton } from '@material-ui/core';
 import AccountTreeRoundedIcon from '@material-ui/icons/AccountTreeRounded';

--- a/components/navigation/ToolbarContents.tsx
+++ b/components/navigation/ToolbarContents.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from '@emotion/styled';
 import { useMediaQuery, useTheme } from '@material-ui/core';
 import dynamic from 'next/dynamic';

--- a/components/navigation/UserMenu.tsx
+++ b/components/navigation/UserMenu.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { css } from '@emotion/react';
 import { IconButton, Popover, Tooltip, useTheme } from '@material-ui/core';
 import AccountCircle from '@material-ui/icons/AccountCircle';

--- a/components/navigation/UserMenuContent.tsx
+++ b/components/navigation/UserMenuContent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link, Typography } from '@material-ui/core';
 import NextLink from 'next/link';
 

--- a/components/operations/OperationApplicationCard.tsx
+++ b/components/operations/OperationApplicationCard.tsx
@@ -1,5 +1,5 @@
 import type { HTMLProps } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import type { InstanceSummary } from '@squonk/data-manager-client';
 import { useGetProjects } from '@squonk/data-manager-client/project';

--- a/components/operations/OperationCards.tsx
+++ b/components/operations/OperationCards.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { InstanceSummary, TaskSummary } from '@squonk/data-manager-client';
 
 import { Grid, Typography } from '@material-ui/core';

--- a/components/operations/OperationJobCard.tsx
+++ b/components/operations/OperationJobCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import type { InstanceSummary } from '@squonk/data-manager-client';
 import { useGetProjects } from '@squonk/data-manager-client/project';

--- a/components/operations/OperationTaskCard.tsx
+++ b/components/operations/OperationTaskCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { TaskSummary } from '@squonk/data-manager-client';

--- a/components/operations/OperationsToolbar.tsx
+++ b/components/operations/OperationsToolbar.tsx
@@ -1,5 +1,4 @@
 import type { Dispatch, SetStateAction } from 'react';
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import {

--- a/components/operations/RerunJobButton.tsx
+++ b/components/operations/RerunJobButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import type { InstanceSummary } from '@squonk/data-manager-client';
 

--- a/components/operations/common/DateTimeListItem.tsx
+++ b/components/operations/common/DateTimeListItem.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { css } from '@emotion/react';
 import { ListItem, ListItemText, useMediaQuery, useTheme } from '@material-ui/core';
 import dayjs from 'dayjs';

--- a/components/operations/common/TerminateInstance.tsx
+++ b/components/operations/common/TerminateInstance.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import type { InstanceSummary } from '@squonk/data-manager-client';

--- a/components/operations/common/TimeLine.tsx
+++ b/components/operations/common/TimeLine.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { InstanceGetResponse, TaskGetResponse, TaskState } from '@squonk/data-manager-client';
 
 import { css } from '@emotion/react';

--- a/components/operations/details/ApplicationDetails.tsx
+++ b/components/operations/details/ApplicationDetails.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { InstanceSummary } from '@squonk/data-manager-client';
 
 import { Grid, ListItem, ListItemText } from '@material-ui/core';

--- a/components/operations/details/JobDetails/JobDetails.tsx
+++ b/components/operations/details/JobDetails/JobDetails.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { InstanceSummary } from '@squonk/data-manager-client';
 
 import { css } from '@emotion/react';

--- a/components/operations/details/TaskDetails.tsx
+++ b/components/operations/details/TaskDetails.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { TaskSummary } from '@squonk/data-manager-client';
 import { useGetTask } from '@squonk/data-manager-client/task';
 

--- a/components/uploads/Dropzone.tsx
+++ b/components/uploads/Dropzone.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import type { DropzoneOptions, FileRejection } from 'react-dropzone';
 import { useDropzone } from 'react-dropzone';
 

--- a/components/uploads/FileTypeOptions.tsx
+++ b/components/uploads/FileTypeOptions.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useGetFileTypes } from '@squonk/data-manager-client/type';
 
 import { Box, Grid, Typography } from '@material-ui/core';

--- a/components/uploads/MimeTypeCard.tsx
+++ b/components/uploads/MimeTypeCard.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { TypeSummary } from '@squonk/data-manager-client';
 
 import { Card, CardContent } from '@material-ui/core';

--- a/components/uploads/ProgressBar.tsx
+++ b/components/uploads/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { FileError } from 'react-dropzone';
 
 import { useGetTask } from '@squonk/data-manager-client/task';

--- a/context/MDXComponentProvider.tsx
+++ b/context/MDXComponentProvider.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import React from 'react';
 
 import { Link, Typography } from '@material-ui/core';
 import { MDXProvider } from '@mdx-js/react';

--- a/context/colorSchemeContext.tsx
+++ b/context/colorSchemeContext.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { createContext, useContext, useState } from 'react';
 
 const STORAGE_KEY =
   process.env.NEXT_PUBLIC_LOCAL_STORAGE_PREFIX ?? 'data-manager-ui' + '-colorScheme';
@@ -38,7 +38,7 @@ const initialState: ColorSchemeState = {
   },
 };
 
-export const ColorSchemeContext = React.createContext<ColorSchemeState>(initialState);
+export const ColorSchemeContext = createContext<ColorSchemeState>(initialState);
 
 export const ColorSchemeProvider: React.FC = ({ children }) => {
   const [scheme, setScheme] = useState(initialScheme);

--- a/context/fileSelectionContext.tsx
+++ b/context/fileSelectionContext.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useReducer } from 'react';
+import { createContext, useContext, useReducer } from 'react';
 
 import type { ProjectId } from '../hooks/currentProjectHooks';
 import { useCurrentProjectId } from '../hooks/currentProjectHooks';
@@ -31,7 +31,7 @@ const initialState: SelectedFilesState = {
   },
 };
 
-export const SelectedFilesContext = React.createContext<SelectedFilesState>(initialState);
+export const SelectedFilesContext = createContext<SelectedFilesState>(initialState);
 
 interface FileStateAction {
   type: 'add-file' | 'remove-file';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Hydrate } from 'react-query/hydration';
 
@@ -37,7 +37,7 @@ export default function App({ Component, pageProps }: AppProps) {
   }
 
   // Material UI for SSR
-  React.useEffect(() => {
+  useEffect(() => {
     // Remove the server-side injected CSS.
     const jssStyles = document.querySelector('#jss-server-side');
     if (jssStyles) {

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Children } from 'react';
 
 import { generateThemes } from '@squonk/mui-theme';
 
@@ -48,7 +48,7 @@ export default class MyDocument extends Document {
     return {
       ...initialProps,
       // Styles fragment is rendered after the app and page rendering finish.
-      styles: [...React.Children.toArray(initialProps.styles), sheets.getStyleElement()],
+      styles: [...Children.toArray(initialProps.styles), sheets.getStyleElement()],
     };
   }
 

--- a/pages/data.tsx
+++ b/pages/data.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 import { Container } from '@material-ui/core';
 import Head from 'next/head';

--- a/pages/executions.tsx
+++ b/pages/executions.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import type {
   ApplicationsGetResponse,

--- a/pages/tasks.tsx
+++ b/pages/tasks.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { QueryClient } from 'react-query';
 import { dehydrate } from 'react-query/hydration';
 

--- a/pages/tasks/[pid].tsx
+++ b/pages/tasks/[pid].tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import React from 'react';
 import { useQueryClient } from 'react-query';
 
 import { getGetInstanceQueryKey, useGetInstances } from '@squonk/data-manager-client/instance';

--- a/utils/LowerCaseTextField.tsx
+++ b/utils/LowerCaseTextField.tsx
@@ -1,6 +1,5 @@
 import type { ChangeEvent } from 'react';
 import { useCallback } from 'react';
-import React from 'react';
 
 import { TextField as MuiTextField } from '@material-ui/core';
 import type { TextFieldProps } from 'formik-material-ui';

--- a/utils/RoleRequired.tsx
+++ b/utils/RoleRequired.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import React from 'react';
 
 import Error from 'next/error';
 


### PR DESCRIPTION
TS 4.5 brought a fix to the VSCode suggestions making it a good DX to not have `import React from 'react'` at the top of every file. This PR removes these and adds snippets that provides component templates conforming to this convention.