### PR TITLE
fix: disable husky hooks during semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HUSKY: 0
           SEMANTIC_RELEASE_DEBUG: true
 
       - name: Capture release SHA


### PR DESCRIPTION
Disable Husky only for the semantic-release step so @semantic-release/git can create the release commit in CI without running developer pre-commit hooks.