### PR TITLE
fix(ci): stop pinning pnpm separately from packageManager

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,6 @@ jobs:
       uses: actions/checkout@v6
     - uses: pnpm/action-setup@v6
       with:
-        version: 11.2.2
         run_install: false
     - name: Setup Node
       uses: actions/setup-node@v6
@@ -48,7 +47,6 @@ jobs:
       uses: actions/checkout@v6
     - uses: pnpm/action-setup@v6
       with:
-        version: 11.2.2
         run_install: false
     - name: Setup Node
       uses: actions/setup-node@v6

--- a/.github/workflows/nextjs_bundle_analysis.yaml
+++ b/.github/workflows/nextjs_bundle_analysis.yaml
@@ -20,7 +20,6 @@ jobs:
 
     - uses: pnpm/action-setup@v6
       with:
-        version: 11.2.2
         run_install: false
     - name: Setup Node
       uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.2.2
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,6 @@ jobs:
       uses: actions/checkout@v6
     - uses: pnpm/action-setup@v6
       with:
-        version: 11.2.2
         run_install: false
     - name: Setup Node
       uses: actions/setup-node@v6

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "@playwright/test";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
-process.loadEnvFile(path.resolve(__dirname, ".env.test.local"));
+// Local runs keep their secrets in this (gitignored) file; CI passes the same values as job-level
+// environment variables and has no file to load. `process.loadEnvFile` throws on a missing path,
+// unlike the `dotenv` call it replaced, so the existence check is what keeps CI working.
+const envFile = path.resolve(__dirname, ".env.test.local");
+if (existsSync(envFile)) {
+  process.loadEnvFile(envFile);
+}
 
 const baseURL = new URL(process.env.BASE_URL as string);
 baseURL.pathname = process.env.BASE_PATH ?? "/";


### PR DESCRIPTION
## The failure

Every job that runs `pnpm/action-setup` has been failing at the setup step — `lint`, `Type-Check` and `test`, on `dev` and on every branch cut from it:

```
Error: Multiple versions of pnpm specified:
  - version 11.2.2 in the GitHub Action config with the key "version"
  - version pnpm@11.15.1 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

No test actually ran — the jobs die before `Install dependencies`. `build` is unaffected because `build.yaml` doesn't use the action.

## Cause

5cc61c7 (`feat!: update data-manager-client to v6`) bumped `packageManager` from `pnpm@11.2.2` to `pnpm@11.15.1` and left the workflows asking for `11.2.2`. v6 of the action treats that disagreement as fatal rather than preferring one.

## Fix

Drop the `version:` input from all five call sites (`lint.yaml` ×2, `test.yaml`, `nextjs_bundle_analysis.yaml`, `release.yml`) so `packageManager` is the single source of truth. That's what the action recommends, and it stops the two drifting apart again the next time Renovate bumps pnpm.

Bumping the pins to `11.15.1` would also go green, but leaves the same trap in place.

## Checking it

The four affected workflows all trigger on this PR, so the run on this branch is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
