### PR TITLE
fix: make the deployed image readable to its own deployment

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,17 @@ NEXT_PUBLIC_APP_VERSION=$npm_package_version
 NEXT_PUBLIC_BASE_PATH=$BASE_PATH
 BETTER_AUTH_BASE_URL=$BASE_URL$VERCEL_URL
 KEYCLOAK_ISSUER_URL=$KEYCLOAK_URL
+
+# The migration from nextjs-auth0 to better-auth kept every deployment-facing
+# name working — BASE_URL, BASE_PATH and KEYCLOAK_URL are derived above — but
+# nextjs-auth0 read these three from the environment itself, so they had no
+# mapping here to carry across. Deployments that still supply the auth0 names
+# are served by these. This file is Next's lowest-priority env file, so a
+# deployment that sets the better-auth names itself always wins.
+BETTER_AUTH_SECRET=$AUTH0_SECRET
+KEYCLOAK_CLIENT_ID=$AUTH0_CLIENT_ID
+KEYCLOAK_CLIENT_SECRET=$AUTH0_CLIENT_SECRET
+
 NEXT_PUBLIC_KEYCLOAK_ISSUER_URL=$KEYCLOAK_URL
 NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=$KEYCLOAK_CLIENT_ID
 

--- a/src/application/apiServers.ts
+++ b/src/application/apiServers.ts
@@ -1,0 +1,71 @@
+import { captureException } from "@sentry/nextjs";
+
+import { withBasePath } from "../utils/app/basePath";
+
+/**
+ * Where this deployment's APIs are.
+ *
+ * These addresses are deployment configuration, not build configuration: the image is built once
+ * and run by whichever installation deploys it, each against its own APIs. `NEXT_PUBLIC_` values
+ * are inlined by `next build`, so they can only carry what a build was told and a published image
+ * has no way to correct them. The server reads the addresses from its own environment, where an
+ * installation puts them, and the browser asks the server that served the page.
+ */
+export interface ApiServers {
+  dataManager: string;
+  accountServer: string;
+  depict: string;
+}
+
+type Environment = Record<string, string | undefined>;
+
+export const API_SERVERS_PATH = "/api/configuration/api-servers";
+
+const UNCONFIGURED: ApiServers = { dataManager: "", accountServer: "", depict: "" };
+
+// The deployment-facing name is the one an installation sets. Its `NEXT_PUBLIC_` twin answers for
+// a build that was handed the addresses — a Vercel deployment — where the two agree anyway.
+// An empty value counts as unset: `.env` derives one name from the other, and a variable the
+// environment never supplied expands to an empty string rather than going missing.
+const read = (env: Environment, name: string): string =>
+  [env[name], env[`NEXT_PUBLIC_${name}`]].find((value) => !!value) ?? "";
+
+export const readApiServers = (env: Environment): ApiServers => ({
+  dataManager: read(env, "DATA_MANAGER_API_SERVER"),
+  accountServer: read(env, "ACCOUNT_SERVER_API_SERVER"),
+  depict: read(env, "DEPICT_API_SERVER"),
+});
+
+let loaded: ApiServers | undefined;
+let inFlight: Promise<ApiServers> | undefined;
+
+/**
+ * The addresses if they have already arrived, so a caller that mounts after the first load renders
+ * with them rather than flashing an unconfigured view on its way to the same answer.
+ */
+export const apiServersSnapshot = (): ApiServers | undefined => loaded;
+
+/**
+ * Asks the server where its APIs are, once per tab. Every caller shares the one request.
+ */
+export const loadApiServers = (fetcher: typeof fetch = fetch): Promise<ApiServers> => {
+  inFlight ??= fetcher(withBasePath(API_SERVERS_PATH))
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`The API server addresses could not be read: ${response.status}`);
+      }
+      loaded = (await response.json()) as ApiServers;
+      return loaded;
+    })
+    .catch((error: unknown) => {
+      // A deployment whose own server cannot say where its APIs are is broken in a way that signing
+      // in again would not mend, so this resolves rather than rejects: the auth recovery in
+      // ApiClientReadyBoundary is left for the failures it can actually recover from. Clearing the
+      // shared promise lets the next caller ask again.
+      captureException(error);
+      inFlight = undefined;
+      return UNCONFIGURED;
+    });
+
+  return inFlight;
+};

--- a/src/features/SDFViewer/SDFViewerData.tsx
+++ b/src/features/SDFViewer/SDFViewerData.tsx
@@ -9,17 +9,18 @@ import { nanoid } from "nanoid";
 import { MolCard } from "../../components/MolCard";
 import CalculationsTable from "../../components/MolCard/CalculationsTable";
 import { ScatterPlot } from "../../components/ScatterPlot/ScatterPlot";
+import { useApiServers } from "../../hooks/useApiServers";
 import { censorConfig, type SDFViewerConfig } from "../../utils/api/sdfViewer";
 import { withBasePath } from "../../utils/app/basePath";
 
-const getCards = (molecules: Must<Molecule>[], propsToHide: string[] = []) => {
+const getCards = (molecules: Must<Molecule>[], depictURL: string, propsToHide: string[] = []) => {
   return molecules.slice(0, 50).map((molecule) => {
     const properties = Object.entries(molecule.properties)
       .map((property) => ({ name: property[0], value: property[1] }))
       .filter((property) => !propsToHide.includes(property.name));
     return (
       <MolCard
-        depictParams={{ depictURL: process.env.NEXT_PUBLIC_DEPICT_API_SERVER ?? "" }}
+        depictParams={{ depictURL }}
         key={molecule.id}
         molFile={molecule.molFile}
         variant="molFile"
@@ -85,6 +86,7 @@ export interface SDFViewerDataProps {
 
 export const SDFViewerData = ({ projectId, path, config }: SDFViewerDataProps) => {
   const { data, isFetching, error } = useSDFRecords(projectId, path, config);
+  const apiServers = useApiServers();
 
   const records = useMemo(() => data ?? [], [data]);
 
@@ -136,6 +138,7 @@ export const SDFViewerData = ({ projectId, path, config }: SDFViewerDataProps) =
         selection
           .map((id) => molecules.find((molecule) => molecule.id === id))
           .filter((molecule): molecule is Must<Molecule> => !!molecule),
+        apiServers?.depict ?? "",
         propsToHide,
       )}
     </Box>

--- a/src/hooks/useApiServers.ts
+++ b/src/hooks/useApiServers.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+import { type ApiServers, apiServersSnapshot, loadApiServers } from "../application/apiServers";
+
+/**
+ * This deployment's API addresses, or undefined until they arrive.
+ *
+ * The API clients read them through their own request gate in `_app`; this is for the components
+ * that address a service directly, and hands back the snapshot when a previous caller has already
+ * loaded them.
+ */
+export const useApiServers = (): ApiServers | undefined => {
+  const [servers, setServers] = useState(apiServersSnapshot);
+
+  useEffect(() => {
+    if (servers) {
+      return;
+    }
+    let isCurrent = true;
+    void loadApiServers().then((next) => {
+      if (isCurrent) {
+        setServers(next);
+      }
+    });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [servers]);
+
+  return servers;
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,6 +13,7 @@ import { enableMapSet } from "immer";
 import { type AppProps } from "next/app";
 import Head from "next/head";
 
+import { type ApiServers, loadApiServers, readApiServers } from "../application/apiServers";
 import { PagePolicyComposer, type PolicyAppComponent } from "../application/PagePolicyComposer";
 import { ConfiguredSnackbarProvider } from "../components/app/ConfiguredSnackbarProvider";
 import { ThemeProviders } from "../components/app/ThemeProviders";
@@ -27,24 +28,40 @@ const openSansFontCss = `
 }
 `;
 
-export const DM_API_URL = process.env.NEXT_PUBLIC_DATA_MANAGER_API_SERVER ?? "";
-export const AS_API_URL = process.env.NEXT_PUBLIC_ACCOUNT_SERVER_API_SERVER ?? "";
+// Where the APIs are is settled by the deployment, not by the build, so the addresses arrive after
+// this module does. On the server they are read straight from the environment; the browser asks the
+// server that served the page, and the gate below holds requests until the answer lands.
+const applyApiServers = ({ dataManager, accountServer }: ApiServers) => {
+  setDMBaseUrl(dataManager);
+  setASBaseUrl(accountServer);
+};
 
-setDMBaseUrl(DM_API_URL);
-setASBaseUrl(AS_API_URL);
+const resolveApiServers = async (): Promise<ApiServers> =>
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  globalThis.window === undefined ? readApiServers(process.env) : loadApiServers();
 
-// Gate all DM/AS Axios requests until the auth token is first set.
-// Runs once at module load (browser only) — already-resolved promises are
+// Shared by every request: the addresses are settled once and awaited thereafter.
+let apiServersReady: Promise<void> | undefined;
+const awaitApiServers = async (): Promise<void> => {
+  apiServersReady ??= resolveApiServers().then(applyApiServers);
+  await apiServersReady;
+};
+
+// Gate all DM/AS Axios requests until the deployment's addresses are known and the auth token is
+// first set. Runs once at module load (browser only) — already-resolved promises are
 // synchronous no-ops, so there is no overhead on subsequent requests.
 
-// After the gate opens, re-read Authorization from the instance's current defaults.
-// We can't rely on what was merged into the config at request-initiation time because
-// setAuthToken() may not have been called yet when the request was first queued.
+// After the gate opens, re-read Authorization and the base URL from the instance's current
+// defaults. We can't rely on what was merged into the config at request-initiation time because
+// neither setAuthToken() nor applyApiServers() may have been called yet when the request was
+// first queued.
 const makeGateInterceptor = (instance: typeof DM_INSTANCE) => {
   const interceptor: NonNullable<Parameters<typeof instance.interceptors.request.use>[0]> = async (
     config,
   ) => {
+    await awaitApiServers();
     await awaitTokenGate();
+    config.baseURL = instance.defaults.baseURL;
     const auth = instance.defaults.headers.common.Authorization as string | undefined;
     if (auth) {
       config.headers.set("Authorization", auth);

--- a/src/pages/api/configuration/api-servers.ts
+++ b/src/pages/api/configuration/api-servers.ts
@@ -1,0 +1,16 @@
+import { type NextApiHandler } from "next";
+
+import { readApiServers } from "../../../application/apiServers";
+
+// Answers the browser's one question about this deployment: where its APIs are. Read from the
+// environment on every request, because the image carries no answer of its own.
+const handler: NextApiHandler = (req, res) => {
+  if (req.method === "GET") {
+    res.setHeader("Cache-Control", "no-store");
+    res.status(200).json(readApiServers(process.env));
+  } else {
+    res.status(405).end("Method not allowed");
+  }
+};
+
+export default handler;

--- a/src/pages/configuration.tsx
+++ b/src/pages/configuration.tsx
@@ -1,6 +1,7 @@
 import { Container } from "@mui/material";
 import { type GetServerSideProps } from "next";
 
+import { readApiServers } from "@/application/apiServers";
 import { pagePolicies, withPagePolicy } from "@/application/pagePolicy";
 
 // Format a value so undefined and empty string are visible
@@ -26,21 +27,20 @@ const ReprLi = ({ title, children }: { children: string | null | undefined; titl
 };
 
 export interface ConfigurationProps {
-  dmAPI: string | null;
-  asAPI: string | null;
+  dmAPI: string;
+  asAPI: string;
+  depictAPI: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const getServerSideProps: GetServerSideProps<ConfigurationProps> = async () => {
-  // These may change between build and deployment. NextJS statically builds these so just using
-  // these "public" variables won't show the correct value.
-  // When undefined a null is passed as undefined isn't valid json.
-  const dmAPI = process.env.NEXT_PUBLIC_DATA_MANAGER_API_SERVER ?? null;
-  const asAPI = process.env.NEXT_PUBLIC_ACCOUNT_SERVER_API_SERVER ?? null;
-  return { props: { dmAPI, asAPI } };
+  // These change between build and deployment, so they are read from the environment this server
+  // is running in rather than from the "public" variables `next build` inlined.
+  const { dataManager, accountServer, depict } = readApiServers(process.env);
+  return { props: { dmAPI: dataManager, asAPI: accountServer, depictAPI: depict } };
 };
 
-export const Configuration = ({ dmAPI, asAPI }: ConfigurationProps) => (
+export const Configuration = ({ dmAPI, asAPI, depictAPI }: ConfigurationProps) => (
   <Container>
     <h1>Configuration</h1>
     <p>
@@ -53,6 +53,7 @@ export const Configuration = ({ dmAPI, asAPI }: ConfigurationProps) => (
       <ReprLi title="Base Path">{process.env.NEXT_PUBLIC_BASE_PATH}</ReprLi>
       <ReprLi title="DM API Server">{dmAPI}</ReprLi>
       <ReprLi title="AS API Server">{asAPI}</ReprLi>
+      <ReprLi title="Depict API Server">{depictAPI}</ReprLi>
     </ul>
     <h2>Auth</h2>
     <ul>

--- a/tests/contracts/api-servers.node.ts
+++ b/tests/contracts/api-servers.node.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+
+import { API_SERVERS_PATH, loadApiServers, readApiServers } from "../../src/application/apiServers";
+
+const publishedImage = {
+  // What a published image carries: `next build` ran without the addresses, so the inlined public
+  // values are empty, and the installation supplies the real ones to the running container.
+  DATA_MANAGER_API_SERVER: "https://an-installation.example/data-manager-api",
+  ACCOUNT_SERVER_API_SERVER: "https://an-installation.example/account-server-api",
+  DEPICT_API_SERVER: "https://an-installation.example/depict",
+  NEXT_PUBLIC_DATA_MANAGER_API_SERVER: "",
+  NEXT_PUBLIC_ACCOUNT_SERVER_API_SERVER: "",
+  NEXT_PUBLIC_DEPICT_API_SERVER: "",
+};
+
+test.describe("API server addresses", () => {
+  test("reads the addresses the installation gave the running container", () => {
+    expect(readApiServers(publishedImage)).toEqual({
+      dataManager: "https://an-installation.example/data-manager-api",
+      accountServer: "https://an-installation.example/account-server-api",
+      depict: "https://an-installation.example/depict",
+    });
+  });
+
+  test("falls back to the values a build was given, so a Vercel deployment is unaffected", () => {
+    expect(
+      readApiServers({
+        NEXT_PUBLIC_DATA_MANAGER_API_SERVER: "https://vercel.example/data-manager-api",
+        NEXT_PUBLIC_ACCOUNT_SERVER_API_SERVER: "https://vercel.example/account-server-api",
+        NEXT_PUBLIC_DEPICT_API_SERVER: "https://vercel.example/depict",
+      }),
+    ).toEqual({
+      dataManager: "https://vercel.example/data-manager-api",
+      accountServer: "https://vercel.example/account-server-api",
+      depict: "https://vercel.example/depict",
+    });
+  });
+
+  test("answers an unconfigured environment with empty addresses, never undefined", () => {
+    expect(readApiServers({})).toEqual({ dataManager: "", accountServer: "", depict: "" });
+  });
+
+  test("asks the server once, however many callers want the addresses", async () => {
+    const asked: string[] = [];
+    const fetcher = ((input: string) => {
+      asked.push(input);
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            dataManager: "https://an-installation.example/data-manager-api",
+            accountServer: "https://an-installation.example/account-server-api",
+            depict: "https://an-installation.example/depict",
+          }),
+      } as Response);
+    }) as unknown as typeof fetch;
+
+    const [first, second, third] = await Promise.all([
+      loadApiServers(fetcher),
+      loadApiServers(fetcher),
+      loadApiServers(fetcher),
+    ]);
+
+    expect(asked).toHaveLength(1);
+    expect(asked[0]).toContain(API_SERVERS_PATH);
+    expect(first).toEqual(second);
+    expect(second).toEqual(third);
+  });
+});

--- a/types/nextjs-routes.d.ts
+++ b/types/nextjs-routes.d.ts
@@ -22,6 +22,7 @@ declare module "nextjs-routes" {
     | StaticRoute<"/administration/usage-inventory">
     | DynamicRoute<"/administration/usage-inventory/[collection]/[resourceId]", { "collection": string; "resourceId": string }>
     | DynamicRoute<"/api/auth/[...all]", { "all": string[] }>
+    | StaticRoute<"/api/configuration/api-servers">
     | StaticRoute<"/api/configuration/ui-version">
     | DynamicRoute<"/api/dm-api/[...dmProxy]", { "dmProxy": string[] }>
     | StaticRoute<"/api/motd">


### PR DESCRIPTION
Two faults that between them stop a Kubernetes deployment of the published image from working. Both date from the better-auth migration (`84a9309`), and neither shows up on Vercel, where the build and the deployment are the same event.

Found while investigating why `data-manager-ui-test.xchem-dev.diamond.ac.uk` (running `7.0.0-dev.3`) cannot log in.

## 1. The auth0 environment variable names are understood again

The migration deliberately kept the deployment-facing names working: `BASE_URL`, `BASE_PATH` and `KEYCLOAK_URL` are still derived in `.env` into the names the app reads. `nextjs-auth0` read the secret and client credentials straight out of the environment, though, so those three had no mapping to carry across, and a deployment supplying them stopped being understood.

Without `BETTER_AUTH_SECRET`, better-auth substitutes its default secret and refuses to run in production — it throws while resolving its context, before routing, so **every** `/api/auth/*` request answers a bare `500`, `/api/auth/ok` included, and there is no way to log in.

`.env` is Next's lowest-priority env file, so a deployment that sets the better-auth names itself still wins. The companion playbook change is InformaticsMatters/squonk2-data-manager-ui-ansible#11; this makes installations that have not taken it work anyway.

Verified by resolving the image's `.env` together with the `.env.production` each playbook generates, through Next's own env loader:

| | before | after |
| --- | --- | --- |
| old playbook (auth0 names) | `BETTER_AUTH_SECRET` undefined | resolves |
| updated playbook (better-auth names) | resolves | resolves, and still wins |

## 2. The API addresses are read at runtime

`_app` set the DM and AS base URLs from `NEXT_PUBLIC_DATA_MANAGER_API_SERVER` and friends, and the SDF viewer read `NEXT_PUBLIC_DEPICT_API_SERVER`. `next build` inlines those, and the image build receives only `GIT_SHA` and `BASE_PATH`, so every published image carries empty addresses — the browser resolves each call against its own origin and reaches nothing. Both deployments show it today: `/configuration` serves `"dmAPI":""`. 6.2.0 was unaffected because it addressed the same-origin proxies instead.

Build args would fix it only by making the image environment-specific, which the one-image DockerHub model does not allow. So the server answers for the addresses instead — it already reads the same variables for its proxies and SSR:

- `GET /api/configuration/api-servers` returns the three addresses, read from the environment per request.
- The existing request gate in `_app` holds the API clients until they arrive, in the same place and for the same reason it already holds them for the auth token.
- `useApiServers` serves components that address a service directly (the depict URL in the SDF viewer).
- `/configuration` now shows what the running server has rather than what the build was told — what its comment always said it wanted to do — and lists the depict address too.

A deployment that only sets the `NEXT_PUBLIC_` names, as Vercel does, is unaffected: those are the fallback.

## Checks

- `tsc --noEmit` clean, `eslint --max-warnings=0` clean over `src` and `tests`.
- 642 contract tests pass, including 4 new ones in `tests/contracts/api-servers.node.ts`.
- 214 acceptance tests pass. Every API call in that suite now goes through the new gate, so the endpoint is exercised end to end — an unreachable one would have left the base URLs empty and failed the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)