### PR TITLE
fix: explain a refused unit deletion instead of claiming lost permission

### DIFF
--- a/src/administration/UnitAccess.tsx
+++ b/src/administration/UnitAccess.tsx
@@ -18,7 +18,7 @@ import {
   evaluateUnitPrivacyCapability,
   isPersonalUnitResource,
 } from "./capabilities";
-import { administrationResourceLabel } from "./failures";
+import { administrationResourceLabel, unitDeletionFailureMessage } from "./failures";
 import {
   effectiveProductPrivacyExplanation,
   inheritedProductPrivacyExplanation,
@@ -134,7 +134,14 @@ const DeleteUnitAction = ({
             try {
               await commands.deleteUnit(unit.id, isPersonalUnit);
             } catch (error) {
-              feedback.report(error, "delete", administrationResourceLabel.unit(unit.id));
+              feedback.fail(
+                unitDeletionFailureMessage(
+                  error,
+                  isPersonalUnit
+                    ? administrationResourceLabel.personalUnit
+                    : administrationResourceLabel.unit(unit.id),
+                ),
+              );
               throw error;
             }
             feedback.announce("Unit deleted");

--- a/src/administration/failures.ts
+++ b/src/administration/failures.ts
@@ -131,3 +131,25 @@ export const administrationMutationFailureMessage = (
       return undefined;
   }
 };
+
+/**
+ * Presents a refused unit deletion. Delete is offered only to a caller the client has already
+ * confirmed may take it, and the Account Server refuses to delete a unit that still holds products,
+ * so a rejection is a precondition the unit carries rather than a permission the caller lost. The
+ * message names that precondition instead of the generic "permission" wording, which sent the owner
+ * of a still-populated personal unit looking for an access problem that was not there.
+ */
+export const unitDeletionFailureMessage = (error: unknown, resource: string): string => {
+  switch (classifyTransportFailure(error).kind) {
+    case "not-found":
+      return `${resource} is no longer available. The displayed resource has not changed.`;
+    case "network":
+    case "rate-limited":
+    case "server":
+    case "timeout":
+      return `Could not delete ${resource}. The displayed resource has not changed; retry is available.`;
+    case "forbidden":
+    case "unknown":
+      return `Could not delete ${resource}. It may still contain projects, datasets or subscriptions that must be removed first.`;
+  }
+};

--- a/src/administration/useAdministrationFeedback.ts
+++ b/src/administration/useAdministrationFeedback.ts
@@ -12,6 +12,8 @@ export const useAdministrationCommandFeedback = () => {
   const { enqueueError, enqueueSnackbar } = useEnqueueError<AsError>();
   return {
     announce: (message: string) => enqueueSnackbar(message, { variant: "success" }),
+    /** States an already-composed failure, for a command whose rejection it explains for itself. */
+    fail: (message: string) => enqueueSnackbar(message, { variant: "error" }),
     report: (error: unknown, action: string, resource: string) => {
       const message = administrationMutationFailureMessage(error, action, resource);
       message ? enqueueSnackbar(message, { variant: "error" }) : enqueueError(error);


### PR DESCRIPTION
## What

When a user deletes a unit from the administration page and the Account Server refuses, the toast now explains the likely cause — the unit still holds products — instead of the misleading *"You no longer have permission to delete unit …"*.

Closes #2001.

## Why

Deleting your own personal unit routes correctly to `DELETE /personal-unit`, and the delete action is only offered to a caller the client has already confirmed may take it. So a 403 here is not a permission problem — it is a precondition: the Account Server refuses to delete a unit that still contains undeleted products. In the reported case the personal unit held a project product and a dataset subscription, yet the message sent the owner looking for an access problem that wasn't there.

## Changes

- `failures.ts` — new `unitDeletionFailureMessage`: a refused deletion reads as *"Could not delete {resource}. It may still contain projects, datasets or subscriptions that must be removed first."* Transient failures keep their retry message; a gone resource still says so.
- `useAdministrationFeedback.ts` — a `fail(message)` method for a command that explains its own rejection.
- `UnitAccess.tsx` — `DeleteUnitAction` reports through the new message and names *"your personal unit"* when it is one.

## Not included

Disabling the delete button on *other users'* personal units was considered and deliberately left out. The only client-side signal that a unit is someone else's personal unit is its name matching the owner's username, and a guard test (`administration-access.node.ts:551`) forbids `capabilities.ts` from deciding anything from a name. That request stays open; this PR covers the reported problem — the useless message.

## Testing

- `pnpm tsc` — clean
- `pnpm lint` — clean
- Node contract tests (`administration-access.node.ts`) — 41 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)