### PR TITLE
fix(projects): title the Manage section in its own heading again

### DIFF
--- a/src/projects/ProjectManage.tsx
+++ b/src/projects/ProjectManage.tsx
@@ -199,6 +199,11 @@ const ProjectManageContent = ({ facts }: { facts: ProjectFacts }) => {
 
   return (
     <Box>
+      {/* Manage titles itself exactly as Files, Run and Results do, so a caller who arrives here
+          is told which section they are in rather than having to infer it from the project. */}
+      <Typography gutterBottom component="h1" variant="h4">
+        Manage
+      </Typography>
       <Typography color="text.secondary" variant="body2">
         {organisation.name} › {unit.name}
       </Typography>
@@ -210,9 +215,9 @@ const ProjectManageContent = ({ facts }: { facts: ProjectFacts }) => {
         <Stack direction="row" spacing={1} sx={{ alignItems: "center", flex: 1, minWidth: 0 }}>
           <FolderOutlined color="action" />
           <Typography
-            component="h1"
+            component="h2"
             sx={{ fontWeight: 600, minWidth: 0, overflowWrap: "anywhere" }}
-            variant="h4"
+            variant="h5"
           >
             {project.name}
           </Typography>

--- a/tests/acceptance/projects.acceptance.ts
+++ b/tests/acceptance/projects.acceptance.ts
@@ -818,7 +818,7 @@ test("Manage presents project facts and available actions to a project administr
 
   await expect(page).toHaveURL(`${acceptanceUrls.app}${managePath}`);
   await expect(
-    page.getByRole("heading", { level: 1, name: "KRAS G12D Lead Optimisation" }),
+    page.getByRole("heading", { level: 2, name: "KRAS G12D Lead Optimisation" }),
   ).toBeVisible();
   await expect(
     page.getByText("Northstar Therapeutics › Medicinal Chemistry & Design"),
@@ -947,7 +947,7 @@ test("a platform administrator without a project role remains an ordinary read-o
   await request.put(`${acceptanceUrls.control}/scenario/${subject}?profile=platform-admin`);
   await login(page, managePath, testInfo);
 
-  await expect(page.getByRole("heading", { level: 1, name: "Acceptance Project" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Acceptance Project" })).toBeVisible();
   await expect(page.getByLabel("Your project roles")).toContainText("No project role");
   await expect(page.getByText(/You have read-only access to this project\./u)).toBeVisible();
   await expect(memberChip(page, "Administrators", `${subject}-observer`)).toBeVisible();
@@ -971,7 +971,7 @@ test("Manage stays available to a project viewer and explains every unavailable 
 
   await expect(page).toHaveURL(`${acceptanceUrls.app}${managePath}`);
   await expect(
-    page.getByRole("heading", { level: 1, name: "KRAS G12D Lead Optimisation" }),
+    page.getByRole("heading", { level: 2, name: "KRAS G12D Lead Optimisation" }),
   ).toBeVisible();
   await expect(page.getByRole("navigation", { name: "Project" })).toBeVisible();
   await expect(page.getByLabel("Your project roles").getByText("Observer")).toBeVisible();
@@ -1023,7 +1023,7 @@ test("Manage owns project privacy and every project role change", async ({ page 
   const subject = subjectFor(testInfo);
   const colleague = `${subject}-observer`;
   await login(page, managePath, testInfo);
-  await expect(page.getByRole("heading", { level: 1, name: "Acceptance Project" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Acceptance Project" })).toBeVisible();
 
   // Privacy. The project's own state answers, and the change is stated where it was made.
   await expect(privacySwitch(page)).toBeChecked();
@@ -1073,7 +1073,7 @@ test("a typed member name is a command, and one that names nobody says so", asyn
   // Someone the directory does not list, so the name can only have arrived by being typed.
   const newcomer = `${subject}-newcomer`;
   await login(page, managePath, testInfo);
-  await expect(page.getByRole("heading", { level: 1, name: "Acceptance Project" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Acceptance Project" })).toBeVisible();
 
   await typeMember(page, "Editors", newcomer);
   await expect(
@@ -1161,7 +1161,7 @@ test("unconfirmed project facts leave changes available and defer to the server"
   const subject = subjectFor(testInfo);
   await request.post(`${acceptanceUrls.control}/scenario/${subject}/caller-account-failure`);
   await login(page, managePath, testInfo);
-  await expect(page.getByRole("heading", { level: 1, name: "Acceptance Project" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 2, name: "Acceptance Project" })).toBeVisible();
 
   // Facts that cannot establish the caller never claim authority, and never claim its absence.
   await expect(page.getByLabel("Your project roles")).toContainText("No project role");


### PR DESCRIPTION
The manage dashboard redesign replaced Manage's `h1` with the project's name, leaving it the only project section that does not say which section it is. The project's name and its unit are already stated by the identity strip in the chrome directly above, so the heading was repeating chrome rather than titling the section, and a caller reading the outline lost the one statement of where they were.

Manage now titles itself at `h1` exactly as Files, Run and Results do, and the project's name keeps its place beneath as the dashboard's own `h2`. The two acceptance tests that have failed on dev since the redesign pass unchanged; the manage assertions the redesign added follow the name down a level.

Fixes #2009