### PR TITLE
feat: compile the application with the React Compiler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The app has its own git repository (InformaticsMatters/squonk2-data-manager-ui),
 
 ## Commands
 
-- `pnpm dev` — dev server (Turbopack).
+- `pnpm dev` — dev server (Turbopack, which the React Compiler's Rust port requires).
 - `pnpm build` — production build. Run the separate strict TypeScript and ESLint commands too.
 - `pnpm generate:client:data-manager` / `pnpm generate:client:account-server` — regenerate one local OpenAPI client from its ignored input in `openapi/`.
 - `pnpm generate:clients` — transactionally regenerate both local OpenAPI clients.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,6 +40,16 @@ let nextConfig = {
       : /** @type {import("next").NextConfig["output"]} */ (process.env.OUTPUT_TYPE),
   generateBuildId: process.env.GIT_SHA ? () => process.env.GIT_SHA ?? null : undefined,
   typescript: { ignoreBuildErrors: true },
+  // Every rule the compiler's own diagnostics ship as is enabled in `eslint.config.mjs`, so the
+  // tree is kept in the shape the compiler can actually compile rather than silently skipping
+  // components it cannot.
+  reactCompiler: true,
+  experimental: {
+    // The native Rust port of the React Compiler, which runs inside Turbopack rather than as a
+    // Babel pass through Node. This is why the build is Turbopack rather than webpack: the option
+    // errors outright under webpack.
+    turbopackRustReactCompiler: true,
+  },
   // reactStrictMode: true, // TODO: Blocked by @rjsf Form using UNSAFE_componentWillReceiveProps
   pageExtensions: ["js", "ts", "jsx", "tsx", "mdx"],
   // The redesign is a clean cutover: a removed route is the ordinary not-found, so this

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "test:smoke": "playwright test --config=playwright.smoke.config.ts",
     "test:debug": "pnpm test:acceptance:headed",
     "test:ci": "pnpm test",
-    "analyze": "ANALYZE=true next build --webpack",
-    "analyze:server": "BUNDLE_ANALYZE=server next build --webpack",
-    "analyze:browser": "BUNDLE_ANALYZE=browser next build --webpack"
+    "analyze": "ANALYZE=true next build",
+    "analyze:server": "BUNDLE_ANALYZE=server next build",
+    "analyze:browser": "BUNDLE_ANALYZE=browser next build"
   },
   "lint-staged": {
     "*.@(js|ts|tsx)": [


### PR DESCRIPTION
Stacked on #2026 — **merge that first.** This PR is only the switch; the compatibility work that makes the switch safe lives there.

Turns the React Compiler on as its **native Rust port inside Turbopack**, so there is no Babel plugin and no new dependency.

## Held back deliberately

`experimental.turbopackRustReactCompiler` is marked experimental and *"not recommended for production"*. This PR stays parked until that settles. #2026 carries all the actual code changes and can land without waiting.

## What it does

`next.config.mjs` sets `reactCompiler: true` **and** `experimental.turbopackRustReactCompiler: true`, introduced in Next 16.3. Per the [option's docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackRustReactCompiler), this runs the compiler as native code inside Turbopack, so `babel-plugin-react-compiler` is not needed.

The same docs state the option **"is only supported with Turbopack. Using it with webpack will throw an error."** #2025 already moved `dev`/`build` to Turbopack, so the only remaining webpack pins are the three `analyze` scripts, which give theirs up here.

## Evidence it actually runs

- Both `next build` and `next dev` print `✓ turbopackRustReactCompiler`.
- Compiler artifacts are in the output: `useMemoCache` appears **23** times across client chunks with the compiler on and **5** with it off (those 5 being React's own runtime export).
- `next dev` is ready in ~215ms.

## Verification

`pnpm lint` (`--max-warnings=0`), `pnpm tsc` and `pnpm build` all pass. `pnpm test` is fully green: 238 acceptance, 808 node and component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
