### PR TITLE
fix: show a completed job's outputs

### DIFF
--- a/src/components/instances/JobDetails/JobOutputSection.tsx
+++ b/src/components/instances/JobDetails/JobOutputSection.tsx
@@ -2,9 +2,9 @@ import { type InstanceGetResponse, type InstanceSummary } from "@/api/data-manag
 
 import { List, ListItem, ListItemAvatar, ListItemText, Typography } from "@mui/material";
 
+import { resultInstanceOutputs } from "../../../projects/instanceFacts";
 import { InputOutputItemIcon } from "./InputOutputItemIcon";
 import { JobLink } from "./JobLink";
-import { type OutputValue } from "./types";
 
 export interface JobOutputSectionProps {
   /**
@@ -14,42 +14,38 @@ export interface JobOutputSectionProps {
 }
 
 /**
- * Displays generated outputs for a task.
+ * Displays generated outputs for a task. A job accounts for its outputs through the definition it
+ * rendered at launch, so the outputs shown are whichever of the instance's own two declarations
+ * accounts for it.
  */
 export const JobOutputSection = ({ instance }: JobOutputSectionProps) => {
-  const outputs = (instance.outputs ?? {}) as Record<string, OutputValue>;
-  const outputsEntries = Object.entries(outputs);
+  const outputs = resultInstanceOutputs(instance);
 
-  if (outputsEntries.length === 0) {
+  if (outputs.length === 0) {
     return <Typography>This job has no outputs</Typography>;
   }
 
   return (
     <List aria-label="list of job outputs">
-      {/* We currently have to assume that the outputs have a consistent type */}
-      {outputsEntries.map(([name, output]) => {
-        const isFile = output.type === "file" || output.type === "files";
-
-        return (
-          <ListItem key={name} sx={{ alignItems: "flex-start" }}>
-            <ListItemAvatar>
-              <InputOutputItemIcon type={isFile ? "file" : "directory"} />
-            </ListItemAvatar>
-            <ListItemText
-              disableTypography
-              primary={<Typography variant="body1">{output.title}</Typography>}
-              secondary={
-                <JobLink
-                  isFile={output.type === "file" || output.type === "files"}
-                  path={output.creates}
-                  projectId={instance.project_id}
-                />
-              }
-              sx={{ m: 0 }}
-            />
-          </ListItem>
-        );
-      })}
+      {outputs.map((output) => (
+        <ListItem key={output.name} sx={{ alignItems: "flex-start" }}>
+          <ListItemAvatar>
+            <InputOutputItemIcon type={output.kind} />
+          </ListItemAvatar>
+          <ListItemText
+            disableTypography
+            primary={<Typography variant="body1">{output.title}</Typography>}
+            secondary={
+              <JobLink
+                isFile={output.kind === "file"}
+                path={output.creates}
+                projectId={instance.project_id}
+              />
+            }
+            sx={{ m: 0 }}
+          />
+        </ListItem>
+      ))}
     </List>
   );
 };

--- a/src/components/instances/JobDetails/types.ts
+++ b/src/components/instances/JobDetails/types.ts
@@ -1,6 +1,0 @@
-export interface OutputValue {
-  title: string;
-  creates: string;
-  type?: "directory" | "file" | "files";
-  "mime-types": string[];
-}

--- a/src/projects/instanceFacts.ts
+++ b/src/projects/instanceFacts.ts
@@ -199,3 +199,95 @@ export const resultInstanceJob = (
  * instance, so the logs of one instance are always addressed through that project's Files.
  */
 export const resultInstanceLogsPath = (instanceId: string) => `/.${instanceId}`;
+
+/**
+ * One output an instance declared, in the form the screen presents it: the name the instance keys
+ * it by, a title to show it under, and the instance-relative path it writes, addressed either as a
+ * file or as a directory.
+ */
+export type ResultInstanceOutput = {
+  creates: string;
+  kind: "directory" | "file";
+  name: string;
+  title: string;
+};
+
+/**
+ * The two fields an instance can declare its outputs in. `outputs` holds the outputs fixed when the
+ * instance was launched, which is what step instances use; `rendered_outputs` is the JSON string a
+ * job's own definition renders, and is the only one a job instance populates.
+ */
+export type ResultInstanceOutputFacts = {
+  outputs?: Record<string, unknown>;
+  rendered_outputs?: string;
+};
+
+/**
+ * The rendered outputs an instance carries. The Data Manager hands them over as a JSON string, so a
+ * string it did not render as JSON declares nothing rather than throwing on the screen that shows
+ * the outputs.
+ */
+const parseRenderedOutputs = (rendered?: string): unknown => {
+  if (rendered === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(rendered);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Whether an output is addressed as a file or as a directory. The Data Manager names a single file
+ * and a glob of files distinctly, and both are located as files; anything else — including an
+ * output that declared no type at all — is located as the directory that contains it, because a
+ * path this client cannot place as a file is not one it can open.
+ */
+const outputKind = (type: unknown): ResultInstanceOutput["kind"] =>
+  type === "file" || type === "files" ? "file" : "directory";
+
+/**
+ * The outputs one declaration accounts for. Only an output naming a path can be located, so one
+ * that names none is not presented at all rather than presented as a link to nowhere, and an
+ * untitled output is shown under the name the instance keys it by.
+ */
+const declaredOutputs = (declared: unknown): ResultInstanceOutput[] => {
+  if (typeof declared !== "object" || declared === null || Array.isArray(declared)) {
+    return [];
+  }
+
+  return Object.entries(declared).flatMap(([name, output]) => {
+    if (typeof output !== "object" || output === null || Array.isArray(output)) {
+      return [];
+    }
+
+    const { creates, title, type } = output as Record<string, unknown>;
+    if (typeof creates !== "string" || creates.trim() === "") {
+      return [];
+    }
+
+    return [
+      {
+        creates,
+        kind: outputKind(type),
+        name,
+        title: typeof title === "string" && title.trim() !== "" ? title : name,
+      },
+    ];
+  });
+};
+
+/**
+ * What one instance produced. A job renders its outputs into `rendered_outputs`, so that is what it
+ * is accounted for by; `outputs` answers for the step instances that fix their outputs at launch,
+ * and for anything a job left unrendered. The rendered field is a JSON string the Data Manager
+ * owns, so a string this client cannot parse leaves the instance accounted for by the field it can
+ * read rather than failing the screen the outputs are shown on.
+ */
+export const resultInstanceOutputs = (
+  instance: ResultInstanceOutputFacts,
+): ResultInstanceOutput[] => {
+  const rendered = declaredOutputs(parseRenderedOutputs(instance.rendered_outputs));
+  return rendered.length > 0 ? rendered : declaredOutputs(instance.outputs);
+};

--- a/tests/acceptance/services/fixtures.ts
+++ b/tests/acceptance/services/fixtures.ts
@@ -865,17 +865,19 @@ export const createScenarioFixtures = (subject: string, profile: ScenarioProfile
           job_version: "1.0.0",
           launched: created,
           name: "Acceptance Instance",
-          outputs: {
+          owner: subject,
+          phase: "COMPLETED",
+          project_id: fixtureIds.project,
+          // A job declares its outputs by rendering its definition, so `outputs` — the outputs
+          // fixed at launch, which only step instances use — stays empty for it.
+          rendered_outputs: JSON.stringify({
             results: {
               creates: "results/docked.sdf",
               "mime-types": ["chemical/x-mdl-sdfile"],
               title: "Docked poses",
               type: "file",
             },
-          },
-          owner: subject,
-          phase: "COMPLETED",
-          project_id: fixtureIds.project,
+          }),
           run_time: "0:01:00",
           started: created,
           stopped: "2026-01-02T03:05:05Z",

--- a/tests/contracts/project-instance-results.node.ts
+++ b/tests/contracts/project-instance-results.node.ts
@@ -16,6 +16,7 @@ import {
   resultInstanceJob,
   resultInstanceKind,
   resultInstanceLogsPath,
+  resultInstanceOutputs,
   resultInstancePollInterval,
   resultInstanceSettlement,
   resultInstanceTerminationAction,
@@ -371,4 +372,106 @@ test("one module owns the addressed instance read and the polling that follows i
       /useQueryClient|invalidateQueries|usePatchInstance|useTerminateInstance/u,
     );
   }
+});
+
+// The rendered outputs of a real job instance: the Data Manager hands them over as a JSON string,
+// keyed by the name the job definition declared the output under.
+const renderedOutputs = JSON.stringify({
+  outputFile: {
+    "annotation-properties": { "derived-from": "inputFile" },
+    creates: "sa-score/scored.sdf",
+    "mime-types": ["chemical/x-mdl-sdfile"],
+    title: "Output file",
+    type: "file",
+  },
+});
+
+test("a job accounts for its outputs through the definition it rendered", () => {
+  // A job populates `rendered_outputs` alone, which is the case that used to report no outputs at
+  // all: the outputs fixed at launch are empty for every job.
+  expect(
+    resultInstanceOutputs(instance({ outputs: {}, rendered_outputs: renderedOutputs })),
+  ).toEqual([
+    { creates: "sa-score/scored.sdf", kind: "file", name: "outputFile", title: "Output file" },
+  ]);
+
+  // Where an instance declares both, what it actually rendered is what it produced.
+  expect(
+    resultInstanceOutputs(
+      instance({
+        outputs: { results: { creates: "results/", title: "Launch-time results" } },
+        rendered_outputs: renderedOutputs,
+      }),
+    ).map((output) => output.title),
+  ).toEqual(["Output file"]);
+
+  // A step instance fixes its outputs at launch and renders none, so those are what it is
+  // accounted for by.
+  expect(
+    resultInstanceOutputs(
+      instance({ outputs: { results: { creates: "results/docked.sdf", title: "Docked poses" } } }),
+    ),
+  ).toEqual([
+    { creates: "results/docked.sdf", kind: "directory", name: "results", title: "Docked poses" },
+  ]);
+
+  // Both fields are optional, so an instance that declared no outputs at all stays a real case.
+  expect(resultInstanceOutputs(instance())).toEqual([]);
+  expect(resultInstanceOutputs(instance({ outputs: {}, rendered_outputs: "{}" }))).toEqual([]);
+});
+
+test("a rendered declaration this client cannot read accounts for nothing on its own", () => {
+  const launched = { results: { creates: "results/docked.sdf", title: "Docked poses" } };
+
+  // The rendered field is a JSON string the Data Manager owns. Anything this client cannot read as
+  // a map of outputs leaves the instance accounted for by the field it can read, rather than
+  // failing the screen the outputs are shown on.
+  for (const rendered of ["", "not json", '"a string"', "[]", "null", "3"]) {
+    expect(
+      resultInstanceOutputs(instance({ outputs: launched, rendered_outputs: rendered })).map(
+        (output) => output.title,
+      ),
+    ).toEqual(["Docked poses"]);
+  }
+
+  // An output that names no path cannot be located, so it is not presented as a link to nowhere.
+  for (const rendered of [
+    JSON.stringify({ outputFile: { title: "Output file" } }),
+    JSON.stringify({ outputFile: { creates: "  ", title: "Output file" } }),
+    JSON.stringify({ outputFile: { creates: 3, title: "Output file" } }),
+    JSON.stringify({ outputFile: "sa-score/scored.sdf" }),
+  ]) {
+    expect(
+      resultInstanceOutputs(instance({ outputs: launched, rendered_outputs: rendered })).map(
+        (output) => output.title,
+      ),
+    ).toEqual(["Docked poses"]);
+  }
+});
+
+/** One instance carrying exactly one rendered output, which is what the Data Manager renders. */
+const renderedOutput = (output: Record<string, unknown>) =>
+  resultInstanceOutputs(instance({ rendered_outputs: JSON.stringify({ outputFile: output }) })).at(
+    0,
+  );
+
+test("an output is located as a file only where the instance said it wrote one", () => {
+  // A single file and a glob of files are both located as files.
+  for (const type of ["file", "files"]) {
+    expect(
+      renderedOutput({ creates: "sa-score/scored.sdf", title: "Output file", type })?.kind,
+    ).toBe("file");
+  }
+
+  // A directory, and a path whose type this client has no rule for, are located as the directory
+  // that contains them: a path it cannot place as a file is not one it can open.
+  for (const type of ["directory", "molecules-smi", undefined, 4]) {
+    expect(renderedOutput({ creates: "sa-score/", title: "Output file", type })?.kind).toBe(
+      "directory",
+    );
+  }
+
+  // An untitled output is shown under the name the instance keys it by.
+  expect(renderedOutput({ creates: "sa-score/scored.sdf" })?.title).toBe("outputFile");
+  expect(renderedOutput({ creates: "sa-score/scored.sdf", title: "  " })?.title).toBe("outputFile");
 });


### PR DESCRIPTION
Closes #2013.

A completed job always reported **"This job has no outputs"**. `GET /instance/{id}` returns two distinct fields, and the outputs section read the wrong one: `outputs` holds the outputs fixed at launch, which only step instances use and which is empty for every job, while a job renders its own into `rendered_outputs`.

## What changed

- `resultInstanceOutputs` in `src/projects/instanceFacts.ts` is now the one place that decides what an instance produced. It prefers `rendered_outputs` — a JSON string the Data Manager owns, so it is parsed fail-soft — and falls back to `outputs`, leaving step instances unaffected. An instance declaring neither still produces the empty message.
- Per output it requires a non-empty `creates` path, because an output naming none cannot be located; maps `file` and `files` to a file link and everything else, including an absent type, to the directory that contains it; and shows an untitled output under the name the instance keys it by.
- `JobOutputSection` renders from that fact. `JobDetails/types.ts` had no other consumer and is gone.

## Tests

- The acceptance job fixture now carries its output in `rendered_outputs` with `outputs` empty, which is the shape a real job has. Reverting the component to read `outputs` fails `instance-results.acceptance.ts`, so this is a real regression guard rather than a fixture that happens to pass.
- Three contract tests in `project-instance-results.node.ts` cover precedence and fallback, rendered declarations this client cannot read, and the file-vs-directory and title rules.

`pnpm tsc`, `pnpm lint` and `pnpm test` pass.

## Note for #1975

`docs/how-to/projects/results` claims a result's outputs can be followed to their files, which was false for every job until now. The expanded-result screenshot can be recaptured once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)