### PR TITLE
fix(results): state read-only access once above the results section

### DIFF
--- a/src/components/modals/ModalWrapper.tsx
+++ b/src/components/modals/ModalWrapper.tsx
@@ -11,6 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 
+import { ReasonsRestatedHere } from "../results/CapabilityReasons";
 import { SlideUpTransition } from "../SlideUpTransition";
 import { type BaseModalWrapperProps } from "./types";
 
@@ -76,7 +77,11 @@ export const ModalWrapper: React.FC<ModalWrapperProps> = ({
           <CloseRoundedIcon />
         </IconButton>
       </DialogTitle>
-      <DialogContent>{children}</DialogContent>
+      {/* A dialog covers the page it opened over, so whatever that page stated once above its
+          controls is restated by the controls in here. */}
+      <DialogContent>
+        <ReasonsRestatedHere>{children}</ReasonsRestatedHere>
+      </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>{closeText}</Button>
         {!!onSubmit && (

--- a/src/components/results/CapabilityReasons.tsx
+++ b/src/components/results/CapabilityReasons.tsx
@@ -1,6 +1,39 @@
+import { createContext, type ReactNode, useContext } from "react";
+
 import { Typography } from "@mui/material";
 
 import { capabilityReason, type ProjectCapability } from "../../projects/capabilities";
+
+/** A stable empty list, so a surface that states nothing of its own never re-renders what it holds. */
+const noReasons: readonly string[] = [];
+
+/** Reasons the surrounding page has already stated, which no control below it repeats. */
+const StatedReasonsContext = createContext<readonly string[]>(noReasons);
+
+/**
+ * States a set of reasons once, for everything rendered inside it. A page whose every control is
+ * withheld for the same reason says so at the top and leaves its controls silent about it, rather
+ * than printing one sentence per card for a fact that belongs to the page.
+ *
+ * Only the reasons given here are taken over: a control withheld for a reason of its own — stale
+ * content, a foreign result, a coin limit — still states that reason where it is.
+ */
+export const ReasonsStatedAbove = ({
+  children,
+  reasons,
+}: {
+  children: ReactNode;
+  reasons: readonly string[];
+}) => <StatedReasonsContext value={reasons}>{children}</StatedReasonsContext>;
+
+/**
+ * Undoes that for a surface of its own. A dialog covers whatever the page said above it, so a
+ * control inside one explains itself in full rather than deferring to a sentence the caller can no
+ * longer read.
+ */
+export const ReasonsRestatedHere = ({ children }: { children: ReactNode }) => (
+  <StatedReasonsContext value={noReasons}>{children}</StatedReasonsContext>
+);
 
 /**
  * States what the actions beside it require. A caller who cannot act on a result can always tell
@@ -11,11 +44,12 @@ import { capabilityReason, type ProjectCapability } from "../../projects/capabil
  * takes a line of its own rather than competing with them for the width of a card.
  */
 export const CapabilityReasons = ({ capabilities }: { capabilities: ProjectCapability[] }) => {
+  const statedAbove = useContext(StatedReasonsContext);
   const reasons = [
     ...new Set(
       capabilities
         .map((capability) => capabilityReason(capability))
-        .filter((reason): reason is string => !!reason),
+        .filter((reason): reason is string => !!reason && !statedAbove.includes(reason)),
     ),
   ];
 

--- a/src/projects/ProjectResults.tsx
+++ b/src/projects/ProjectResults.tsx
@@ -8,9 +8,15 @@ import { useFamilyRoute } from "../application/FamilyRouteResolution";
 import { CenterLoader } from "../components/CenterLoader";
 import { InstanceDetails } from "../components/instances/InstanceDetails";
 import { InstanceResultCard } from "../components/instances/InstanceResultCard";
+import { ReasonsStatedAbove } from "../components/results/CapabilityReasons";
 import { ResultTaskCard } from "../components/tasks/ResultTaskCard";
 import { ResultWorkflowSteps } from "../components/workflows/ResultWorkflowSteps";
 import { WorkflowResultCard } from "../components/workflows/WorkflowResultCard";
+import {
+  projectEditorRequirementStatements,
+  projectIsReadOnly,
+  projectReadOnlyStatement,
+} from "./capabilities";
 import { resolveResultInstanceLifecycle, resultInstanceSettlement } from "./instanceFacts";
 import { type ProjectFacts, useProjectFacts } from "./projectFacts";
 import { ProjectResultDetail } from "./ProjectResultDetail";
@@ -44,6 +50,9 @@ type ResultsRoute = Extract<ProjectRoute, { kind: "result" | "results" }>;
 
 const isResultsRoute = (route: FamilyRoute): route is ResultsRoute =>
   route.kind === "results" || route.kind === "result";
+
+/** A stable empty list, so a page that states nothing above the cards never re-renders them. */
+const noReasons: readonly string[] = [];
 
 /** How one listed result accounted for its own progress, where its kind accounts for any. */
 type ResultProgressFacts = Pick<
@@ -221,6 +230,10 @@ const ResultsSection = ({
   const handleTypesChange = (types?: readonly ResultFilterType[]) =>
     handleStateChange({ search: state.search, types });
   const statement = resultsFilterStatement(state.definition, results.definition);
+  // Read-only access withholds the same actions on every result the project owns, so the section
+  // states that once above whatever it is showing and the cards below it stay silent about it. A
+  // dialog opened from here covers that sentence, so its own controls go on explaining themselves.
+  const readOnly = facts !== undefined && projectIsReadOnly(facts);
 
   // The list narrows to the definition the catalogue resolved, never to the identifier the URL
   // carries: that identifier names one version, and the version-agnostic case must stay expressible.
@@ -293,23 +306,37 @@ const ResultsSection = ({
             </Alert>
           ) : null}
 
+          {readOnly ? (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              {projectReadOnlyStatement}
+            </Alert>
+          ) : null}
+
           {facts === undefined ? (
             <CenterLoader />
-          ) : route.kind === "result" ? (
-            <>
-              <Button component={Link} href={projectLinks.results(projectId, state)} sx={{ mb: 1 }}>
-                All results
-              </Button>
-              <ProjectResultDetail facts={facts} results={results} route={route} />
-            </>
           ) : (
-            <ResultsList
-              facts={facts}
-              items={shown}
-              results={results}
-              routeProjectId={projectId}
-              state={state}
-            />
+            <ReasonsStatedAbove reasons={readOnly ? projectEditorRequirementStatements : noReasons}>
+              {route.kind === "result" ? (
+                <>
+                  <Button
+                    component={Link}
+                    href={projectLinks.results(projectId, state)}
+                    sx={{ mb: 1 }}
+                  >
+                    All results
+                  </Button>
+                  <ProjectResultDetail facts={facts} results={results} route={route} />
+                </>
+              ) : (
+                <ResultsList
+                  facts={facts}
+                  items={shown}
+                  results={results}
+                  routeProjectId={projectId}
+                  state={state}
+                />
+              )}
+            </ReasonsStatedAbove>
           )}
         </Box>
       </Box>

--- a/src/projects/capabilities.ts
+++ b/src/projects/capabilities.ts
@@ -199,6 +199,35 @@ const evaluateSpendingAction =
       : { status: "enabled" };
   };
 
+/**
+ * The sentences an editor-only action states when the caller holds no ordinary authority over the
+ * project. Each one says the same thing about the project rather than something about the action
+ * it withholds, so a page that offers many of them can state that fact once, above them all,
+ * instead of repeating it on every control.
+ */
+export const projectEditorRequirements = {
+  archiveInstances:
+    "You must be a project editor or administrator to archive instances in this project.",
+  changeFiles: "You must be a project editor or administrator to change project files.",
+  deleteTasks: "You must be a project editor or administrator to delete tasks in this project.",
+  runWork: "You must be a project editor or administrator to run work in this project.",
+  stopInstances:
+    "You must be a project editor or administrator to stop or delete instances in this project.",
+  stopWorkflows:
+    "You must be a project editor or administrator to stop or delete workflows in this project.",
+} as const;
+
+/** Every such sentence, for a page stating them once in place of the controls that carry them. */
+export const projectEditorRequirementStatements: readonly string[] =
+  Object.values(projectEditorRequirements);
+
+/**
+ * What a page says in their place. It states the one fact they all rest on, so a caller who cannot
+ * act still learns why before reading a single disabled control.
+ */
+export const projectReadOnlyStatement =
+  "You have read-only access to this project, so you cannot run, stop, delete, or archive work in it.";
+
 export const evaluateProjectPrivacyCapability = evaluateAdministratorAction(
   "You must be a project administrator to change project privacy.",
 );
@@ -222,7 +251,7 @@ export const evaluateProjectDeletionCapability = evaluateAdministratorAction(
 /** Every linked subscription accounts for storage, so file changes need no instance accounting. */
 const evaluateFileSpend = evaluateSpendingAction({
   limitReason: "This project's subscription is at its coin limit, so files cannot be changed.",
-  requirement: "You must be a project editor or administrator to change project files.",
+  requirement: projectEditorRequirements.changeFiles,
   unreadableReason: unreadableSubscriptionReasons.files,
 });
 
@@ -287,7 +316,7 @@ export const evaluateProjectDatasetCreationCapability = (
 
 export const evaluateProjectExecutionCapability = evaluateSpendingAction({
   limitReason: "This project's subscription is at its coin limit, so work cannot be run.",
-  requirement: "You must be a project editor or administrator to run work in this project.",
+  requirement: projectEditorRequirements.runWork,
   unaccountableReason:
     "This project's subscription does not account for instances, so running work cannot be established as safe.",
   unreadableReason: unreadableSubscriptionReasons.execution,
@@ -365,9 +394,7 @@ const evaluateResultAction =
   };
 
 const evaluateTerminationAuthority = evaluateResultAction(
-  evaluateEditorAction(
-    "You must be a project editor or administrator to stop or delete instances in this project.",
-  ),
+  evaluateEditorAction(projectEditorRequirements.stopInstances),
 );
 
 /**
@@ -400,15 +427,11 @@ export const evaluateResultTerminationCapability = (
 };
 
 export const evaluateResultArchiveCapability = evaluateResultAction(
-  evaluateEditorAction(
-    "You must be a project editor or administrator to archive instances in this project.",
-  ),
+  evaluateEditorAction(projectEditorRequirements.archiveInstances),
 );
 
 const evaluateTaskDeletionAuthority = evaluateResultAction(
-  evaluateEditorAction(
-    "You must be a project editor or administrator to delete tasks in this project.",
-  ),
+  evaluateEditorAction(projectEditorRequirements.deleteTasks),
 );
 
 /**
@@ -445,9 +468,7 @@ export const evaluateResultTaskDeletionCapability = (
 };
 
 const evaluateWorkflowLifecycleAuthority = evaluateResultAction(
-  evaluateEditorAction(
-    "You must be a project editor or administrator to stop or delete workflows in this project.",
-  ),
+  evaluateEditorAction(projectEditorRequirements.stopWorkflows),
 );
 
 /**
@@ -482,7 +503,7 @@ export const evaluateResultWorkflowLifecycleCapability = (
 export const evaluateResultRerunCapability = evaluateResultAction(
   evaluateSpendingAction({
     limitReason: "This project's subscription is at its coin limit, so work cannot be run.",
-    requirement: "You must be a project editor or administrator to run work in this project.",
+    requirement: projectEditorRequirements.runWork,
     unaccountableReason:
       "This project's subscription does not account for instances, so running work cannot be established as safe.",
     unreadableReason: unreadableSubscriptionReasons.execution,

--- a/tests/acceptance/instance-results.acceptance.ts
+++ b/tests/acceptance/instance-results.acceptance.ts
@@ -294,16 +294,16 @@ test("a project viewer reads an instance and is told what changing it requires",
   await expect(page.getByRole("button", { name: "Delete", exact: true })).toBeDisabled();
   await expect(page.getByRole("button", { name: "Archive" })).toBeDisabled();
   await expect(page.getByRole("button", { name: "Run again" })).toBeDisabled();
+  // What read-only access withholds is a fact of the project, so the section states it once above
+  // the result rather than once per withheld control.
   await expect(
     page.getByText(
-      "You must be a project editor or administrator to stop or delete instances in this project.",
+      "You have read-only access to this project, so you cannot run, stop, delete, or archive work in it.",
     ),
   ).toBeVisible();
   await expect(
-    page.getByText(
-      "You must be a project editor or administrator to archive instances in this project.",
-    ),
-  ).toBeVisible();
+    page.getByText("You must be a project editor or administrator", { exact: false }),
+  ).toHaveCount(0);
 });
 
 test("a rejected instance command preserves the project and route it was rejected in", async ({
@@ -616,7 +616,9 @@ test("a project viewer is told what running an instance's job again requires", a
   // there is told so rather than being offered a launch the Data Manager would refuse.
   await expect(page.getByRole("button", { name: "Run again" })).toBeDisabled();
   await expect(
-    page.getByText("You must be a project editor or administrator to run work in this project."),
+    page.getByText(
+      "You have read-only access to this project, so you cannot run, stop, delete, or archive work in it.",
+    ),
   ).toBeVisible();
   await expect(page).toHaveURL(`${acceptanceUrls.app}${jobDetail}`);
 
@@ -628,6 +630,7 @@ test("a project viewer is told what running an instance's job again requires", a
   await expect(dialog).toBeVisible();
   await expect(dialog.getByLabel("Batch size")).toHaveValue("250");
   await expect(page.getByRole("button", { name: "Run", exact: true })).toBeDisabled();
+  // The dialog covers the page's own read-only alert, so it states what the launch requires itself.
   await expect(
     dialog.getByText("You must be a project editor or administrator to run work in this project."),
   ).toBeVisible();

--- a/tests/acceptance/results.acceptance.ts
+++ b/tests/acceptance/results.acceptance.ts
@@ -123,19 +123,16 @@ test("Results never leave the project in the URL, even across two projects in on
 
   // The same caller only observes this project, so the same actions are withheld and explained.
   // Capability presentation therefore follows the project a result belongs to, not the caller.
+  // The explanation is the list's own, stated once above it rather than on every card in it.
   await expect(page.getByRole("button", { name: "Archive" })).toBeDisabled();
   await expect(
-    page
-      .getByText(
-        "You must be a project editor or administrator to archive instances in this project.",
-      )
-      .first(),
+    page.getByText(
+      "You have read-only access to this project, so you cannot run, stop, delete, or archive work in it.",
+    ),
   ).toBeVisible();
   await expect(
-    page
-      .getByText("You must be a project editor or administrator to delete tasks in this project.")
-      .first(),
-  ).toBeVisible();
+    page.getByText("You must be a project editor or administrator", { exact: false }),
+  ).toHaveCount(0);
 
   // Every Results read the Data Manager received named a project, and only ever a project the URL
   // had addressed at the time.
@@ -306,23 +303,17 @@ test("a project viewer reads results and is told what each unavailable action re
 
   await expect(page.getByRole("heading", { level: 1, name: "Results" })).toBeVisible();
   await expect(page.getByText("Acceptance Instance")).toBeVisible();
+
+  // What read-only access withholds is a fact of the project, so the list states it once above
+  // every card rather than repeating a requirement on each of them.
   await expect(
-    page
-      .getByText(
-        "You must be a project editor or administrator to stop or delete instances in this project.",
-      )
-      .first(),
-  ).toBeVisible();
+    page.getByText(
+      "You have read-only access to this project, so you cannot run, stop, delete, or archive work in it.",
+    ),
+  ).toHaveCount(1);
   await expect(
-    page
-      .getByText("You must be a project editor or administrator to delete tasks in this project.")
-      .first(),
-  ).toBeVisible();
-  await expect(
-    page
-      .getByText("You must be a project editor or administrator to run work in this project.")
-      .first(),
-  ).toBeVisible();
+    page.getByText("You must be a project editor or administrator", { exact: false }),
+  ).toHaveCount(0);
 
   // Every mutation the viewer cannot make is offered as an explained, disabled control.
   await expect(page.getByRole("button", { name: "Run again" })).toBeDisabled();

--- a/tests/acceptance/task-results.acceptance.ts
+++ b/tests/acceptance/task-results.acceptance.ts
@@ -187,7 +187,7 @@ test("a project viewer reads a task and is told what deleting it requires", asyn
   await expect(page.getByRole("button", { name: "Delete", exact: true })).toBeDisabled();
   await expect(
     page.getByText(
-      "You must be a project editor or administrator to delete tasks in this project.",
+      "You have read-only access to this project, so you cannot run, stop, delete, or archive work in it.",
     ),
   ).toBeVisible();
 });

--- a/tests/acceptance/workflow-results.acceptance.ts
+++ b/tests/acceptance/workflow-results.acceptance.ts
@@ -250,7 +250,7 @@ test("a project viewer reads a workflow and is told what changing it requires", 
   await expect(page.getByRole("button", { name: "Delete", exact: true })).toBeDisabled();
   await expect(
     page.getByText(
-      "You must be a project editor or administrator to stop or delete workflows in this project.",
+      "You have read-only access to this project, so you cannot run, stop, delete, or archive work in it.",
     ),
   ).toBeVisible();
 });


### PR DESCRIPTION
## Problem

On the project Results page an observer read the same requirement on every card:

> You must be a project editor or administrator to stop or delete instances in this project. You must be a project editor or administrator to run work in this project. You must be a project editor or administrator to archive instances in this project.

Three sentences, repeated per card, all saying one thing about the project rather than anything about the individual result.

## Change

The Results section now states it once, as an `<Alert severity="info">` above whatever it is showing — the list and an addressed result alike:

> You have read-only access to this project, so you cannot run, stop, delete, or archive work in it.

- `capabilities.ts` names the editor-requirement sentences (`projectEditorRequirements`) and exports them as a list beside the single statement a page shows in their place. Evaluator behaviour and wording are unchanged.
- `CapabilityReasons` gains `ReasonsStatedAbove`, which drops the reasons a page has already stated, and `ReasonsRestatedHere`, its inverse.
- `ModalWrapper` applies the inverse to every dialog: a dialog covers the alert, so the rerun form and the launch modals go on explaining their own disabled controls rather than pointing at a sentence the caller can no longer read.

A result withheld for a reason of its own — stale content, a foreign project, a coin limit, unconfirmed permission — still explains itself on its own card.

## Tests

The read-only acceptance tests for the results list and for instance, task, and workflow detail now require the single alert, and the list test requires zero per-card requirement sentences. The rerun-dialog assertion is unchanged and pins the restatement.

`pnpm tsc`, `pnpm lint` clean; acceptance 238 passed, contract/component 824 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)