### PR TITLE
fix(run): keep an instance's own name when it is run again

### DIFF
--- a/src/components/runCards/JobCard/JobModal.tsx
+++ b/src/components/runCards/JobCard/JobModal.tsx
@@ -16,6 +16,7 @@ import { launchIsSendable } from "../../../projects/runLaunch";
 import {
   declaredInputDefaults,
   type InputData,
+  launchNameDefault,
   launchVariables,
   readRunDefinitionVariables,
   runInputsAreSupplied,
@@ -73,11 +74,10 @@ export const JobModal = ({
   const { data: job } = useGetJob(jobId, undefined, {
     query: { retry: jobId === TEST_JOB_ID ? 1 : 3 },
   });
-  // The job's own name once the definition answers; until then whatever the inherited instance was
-  // named, or nothing at all.
-  const [nameState, setNameState] = useStateResetOn(
-    job?.job,
-    (jobName) => jobName ?? instance?.job_name ?? "",
+  // The name the inherited instance was run under — its own `name`, not the `job_name` the job
+  // definition gave it — and only where there is none the job's own identifier once it answers.
+  const [nameState, setNameState] = useStateResetOn(job?.job, (jobName) =>
+    launchNameDefault(instance?.name, jobName),
   );
 
   const spec = instance?.application_specification;

--- a/src/projects/runLaunchForm.ts
+++ b/src/projects/runLaunchForm.ts
@@ -136,3 +136,22 @@ const workflowName = AppApiWorkflowRunBody.shape.as_name;
  */
 export const workflowLaunchNameProblem = (name: string): string | undefined =>
   workflowName.safeParse(name).success ? undefined : nameRequirement;
+
+/**
+ * The name a launch form opens under. An instance carries what it was run with, and the name it
+ * was run under is part of that, so a rerun keeps the name that distinguished it from every other
+ * run of the same definition. The definition's own identifier is the default for a fresh launch
+ * only — it arrives after the form is drawn, so preferring it would let it overwrite the inherited
+ * name every time, which is the one thing a rerun could not survive.
+ */
+export const launchNameDefault = (
+  instanceName: string | undefined,
+  definitionName: string | undefined,
+): string => {
+  // A name of nothing distinguishes no run, so it is no more a name than an absent one.
+  if (instanceName !== undefined && instanceName !== "") {
+    return instanceName;
+  }
+
+  return definitionName ?? "";
+};

--- a/tests/contracts/project-run-launch-form.node.ts
+++ b/tests/contracts/project-run-launch-form.node.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import {
   declaredInputDefaults,
+  launchNameDefault,
   launchVariables,
   readRunDefinitionVariables,
   runInputsAreSupplied,
@@ -200,6 +201,35 @@ test.describe("The name a running workflow is created under", () => {
   });
 });
 
+test.describe("The name a launch form opens under", () => {
+  test("a fresh launch is named after the definition it will run", () => {
+    // Nothing was inherited, so the definition's own identifier is the only name there is to offer.
+    expect(launchNameDefault(undefined, "sa-score")).toBe("sa-score");
+  });
+
+  test("a rerun keeps the name its instance was run under", () => {
+    // The definition answers after the form is drawn, so a name taken from the definition would
+    // arrive last and always win: the name that distinguished this run would be the one thing a
+    // rerun did not restore.
+    expect(launchNameDefault("Second pass, tighter cutoff", "sa-score")).toBe(
+      "Second pass, tighter cutoff",
+    );
+    expect(launchNameDefault("Second pass, tighter cutoff", undefined)).toBe(
+      "Second pass, tighter cutoff",
+    );
+  });
+
+  test("an instance named nothing is named after the definition, as a fresh launch is", () => {
+    // A name of nothing distinguishes no run, so there is nothing there to keep.
+    expect(launchNameDefault("", "sa-score")).toBe("sa-score");
+  });
+
+  test("a form with neither a definition nor an inherited name opens empty", () => {
+    // The field is a text field the user may type into, so it holds a string either way.
+    expect(launchNameDefault(undefined, undefined)).toBe("");
+  });
+});
+
 const source = (file: string) => readFileSync(path.join(process.cwd(), "src", file), "utf8");
 
 test.describe("Launch form ownership", () => {
@@ -216,6 +246,17 @@ test.describe("Launch form ownership", () => {
       // did not enter them would withhold a launch over an input already answered.
       expect(source(modal)).toContain("declaredInputDefaults");
     }
+  });
+
+  test("a rerun's inherited name is not overwritten by the definition it reruns", () => {
+    const job = source("components/runCards/JobCard/JobModal.tsx");
+    // The one rule decides the field's opening name, so the definition's identifier cannot be
+    // preferred over the name the inherited instance carried.
+    expect(job).toContain("launchNameDefault(instance?.name");
+    // `job_name` is the name the job definition carries, one every run of it shares, so a field
+    // seeded from it would restore the definition's name rather than this run's own.
+    expect(job).not.toContain("instance?.job_name");
+    expect(job).not.toMatch(/jobName \?\? instance/u);
   });
 
   test("no definition form reads its declared variables as the values to run with", () => {


### PR DESCRIPTION
Closes #2017

**Run again** restored an instance's inputs and options but not the name it was run under. The job definition is fetched after the form is drawn, so its identifier arrived last and overwrote whatever the instance supplied — a run deliberately named to distinguish it lost that name the moment it was repeated.

## What the issue got wrong

The issue pointed at `instance.job_name`. That is the name the *job definition* carries — every run of `nop` is "A better do-nothing Job for testing" — so seeding the field from it restores the definition's name, not this run's. The instance's own name is `instance.name`. Confirmed against a live rerun of an instance named `test name`.

## The change

- `launchNameDefault` in `src/projects/runLaunchForm.ts` decides the opening name in one place: the instance's own name where there is one, the job's identifier for a fresh launch, an empty field otherwise. An instance named nothing is treated as naming nothing.
- `JobModal` computes its name state through that rule, so a definition arriving late can no longer win.
- Contract tests cover the rule's four cases, and an ownership test pins that `JobModal` uses it and that `instance?.job_name` does not come back.

`pnpm tsc`, `pnpm lint`, and the full `playwright.config.ts` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)