### PR TITLE
fix(auth): send no credentials rather than an empty bearer token

### DIFF
--- a/src/api/runtime/createAxiosRuntime.ts
+++ b/src/api/runtime/createAxiosRuntime.ts
@@ -5,8 +5,20 @@ export const createAxiosRuntime = () => {
 
   return {
     instance,
+    /**
+     * Present the caller's credentials on every request, or present none at all.
+     *
+     * An empty token is not a credential. Writing one anyway sends `Bearer ` — a header the API can
+     * only reject, and one that reads in a network log as a token that went missing somewhere in
+     * this application rather than as a caller who has none. The header is removed instead, so a
+     * request made without a token is plainly unauthenticated.
+     */
     setAuthToken: (token: string) => {
-      instance.defaults.headers.common.Authorization = `Bearer ${token}`;
+      if (token) {
+        instance.defaults.headers.common.Authorization = `Bearer ${token}`;
+        return;
+      }
+      delete instance.defaults.headers.common.Authorization;
     },
     setBaseUrl: (baseUrl: string) => {
       instance.defaults.baseURL = baseUrl;

--- a/src/application/ApiClientReadyBoundary.tsx
+++ b/src/application/ApiClientReadyBoundary.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import { Alert } from "@mui/material";
+import { captureMessage } from "@sentry/nextjs";
 
 import { AuthButton } from "../components/auth/AuthButton";
 import { CenterLoader } from "../components/CenterLoader";
@@ -53,6 +54,16 @@ export const ApiClientReadyBoundary = ({ children }: { children: ReactNode }) =>
       () => setReauthenticationSpent(true),
     );
   }, [status]);
+
+  useEffect(() => {
+    if (reauthenticationSpent) {
+      // Signing in again is the recovery for a session that cannot authorise the clients, so the
+      // individual refusals are ordinary and are only logged. One that survives the recovery is
+      // not: the deployment is handing out sessions no amount of signing in makes usable, which is
+      // the state worth being told about.
+      captureMessage("A session could not authorise the API clients after signing in again");
+    }
+  }, [reauthenticationSpent]);
 
   if (status === "error" && reauthenticationSpent) {
     return (

--- a/src/hooks/useSetupApiClients.ts
+++ b/src/hooks/useSetupApiClients.ts
@@ -79,8 +79,18 @@ export const useSetupApiClients = () => {
         if (!isCurrent) {
           return;
         }
-        captureException(error);
-        console.error("Could not obtain an access token for this session", error);
+        if (error instanceof AccessTokenUnavailableError) {
+          // An answer the auth server gave on purpose, about a session that has simply ended. The
+          // boundary above recovers from it by signing in again and says so if that does not work,
+          // and reporting every one of them as an exception would bury the failures that are this
+          // application's fault among the far more numerous ones that are not.
+          console.warn(
+            `This session has no access token (${error.code ?? "no code"}); the API clients are unauthenticated`,
+          );
+        } else {
+          captureException(error);
+          console.error("Could not obtain an access token for this session", error);
+        }
         setDMAuthToken("");
         setASAuthToken("");
         completeSetup("error");

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -69,6 +69,11 @@ const makeGateInterceptor = (instance: typeof DM_INSTANCE) => {
     const auth = instance.defaults.headers.common.Authorization as string | undefined;
     if (auth) {
       config.headers.set("Authorization", auth);
+    } else {
+      // Axios merged the defaults into this config when the request was first made, so a request
+      // that queued while a token was still expected would otherwise go out carrying one that has
+      // since been withdrawn.
+      config.headers.delete("Authorization");
     }
     return config;
   };

--- a/tests/contracts/api-client-credentials.node.ts
+++ b/tests/contracts/api-client-credentials.node.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+import { createAxiosRuntime } from "../../src/api/runtime/createAxiosRuntime";
+
+const authorizationOf = (runtime: ReturnType<typeof createAxiosRuntime>) =>
+  runtime.instance.defaults.headers.common.Authorization;
+
+test.describe("API client credentials", () => {
+  test("presents the caller's token on every request once it is known", () => {
+    const runtime = createAxiosRuntime();
+
+    runtime.setAuthToken("a-token");
+
+    expect(authorizationOf(runtime)).toBe("Bearer a-token");
+  });
+
+  test("sends no Authorization header at all when there is no token", () => {
+    const runtime = createAxiosRuntime();
+
+    runtime.setAuthToken("");
+
+    // The failure this guards against is `Bearer `: a header the API can only reject, sent on
+    // behalf of a session that has none.
+    expect(authorizationOf(runtime)).toBeUndefined();
+  });
+
+  test("withdraws a token that has stopped working", () => {
+    const runtime = createAxiosRuntime();
+
+    runtime.setAuthToken("a-token");
+    runtime.setAuthToken("");
+
+    expect(authorizationOf(runtime)).toBeUndefined();
+  });
+
+  test("keeps each client's credentials to itself", () => {
+    const dataManager = createAxiosRuntime();
+    const accountServer = createAxiosRuntime();
+
+    dataManager.setAuthToken("a-token");
+
+    expect(authorizationOf(accountServer)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The failure

A signed-in session whose access token cannot be obtained errors and then goes on making requests the API can only reject:

```
Could not obtain an access token for this session AccessTokenUnavailableError: Account not found
    at useSetupApiClients.useEffect (src/hooks/useSetupApiClients.ts:72:17)
```

`useSetupApiClients` clears the token on both clients on that path, but `createAxiosRuntime.setAuthToken` wrote `` `Bearer ${token}` `` whatever the token was — so clearing it produced the literal header `Bearer `. The gate interceptor in `_app.tsx` tested `if (auth)`, which `"Bearer "` passes, and copied it onto every request. Releasing the token gate on the error path is correct (public pages must not hang), so those requests went out.

In a network log the result reads as a token this application lost somewhere, rather than as a caller who has none.

## Changes

- **`createAxiosRuntime`** — an empty token removes the `Authorization` default instead of writing `Bearer `.
- **`_app.tsx` gate interceptor** — removes `Authorization` from the config when the defaults hold none. Axios merges defaults in at request-initiation time, so a request that queued behind the gate while a token was still expected would otherwise carry one that has since been withdrawn.
- **`useSetupApiClients`** — `AccessTokenUnavailableError` is an answer the auth server gave on purpose about a session that has ended (`ACCOUNT_NOT_FOUND`, a 400 from better-auth's `getAccessToken`). It now logs a warning carrying the code instead of `console.error` + `captureException`.
- **`ApiClientReadyBoundary`** — the Sentry report moves to the failure that survives signing in again. That is the state worth being told about, and it was previously buried among the routine refusals.

`ApiClientReadyBoundary`'s existing recovery — sign out, sign in again, show the terminal alert once the tab's claim is spent — is unchanged. This error is exactly what it was built for; what changes is that the interim no longer produces doomed requests or exception reports.

## Testing

- New `tests/contracts/api-client-credentials.node.ts` pins the header behaviour, including the `Bearer ` regression directly.
- Full contract suite (791 tests), `pnpm tsc` and `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)