### PR TITLE
fix(run): state a disabled job's remedy with its reason

### DIFF
--- a/src/projects/runFacts.ts
+++ b/src/projects/runFacts.ts
@@ -190,8 +190,23 @@ export const findRunDefinition = (
   );
 
 /**
+ * Ends a sentence the Data Manager wrote, so what it says can be read beside sentences of our own.
+ * The reason and the remedy arrive as free text and neither is promised to be punctuated, so a
+ * sentence that already ends is left as it stands rather than stopped twice.
+ */
+const asSentence = (text: string): string => {
+  const trimmed = text.trim();
+
+  return [".", "!", "?"].some((stop) => trimmed.endsWith(stop)) ? trimmed : `${trimmed}.`;
+};
+
+/**
  * Why a definition cannot be run whatever authority the caller holds. The Data Manager disables
  * individual jobs, and says why, so that reason is the definition's own rather than the project's.
+ *
+ * Where it also offers a remedy — which it does for the reasons a caller can actually do something
+ * about, a missing licence being the documented case — the remedy is stated with the reason, so the
+ * caller is told the fix that was offered alongside the problem rather than the problem alone.
  */
 export const runDefinitionUnavailability = (
   item: RunDefinitionItem,
@@ -204,7 +219,11 @@ export const runDefinitionUnavailability = (
   if (!job.disabled) {
     return undefined;
   }
-  return job.disabled_reason ?? "This job is disabled, so it cannot be run.";
+  const reason = job.disabled_reason?.trim()
+    ? asSentence(job.disabled_reason)
+    : "This job is disabled, so it cannot be run.";
+
+  return job.disabled_remedy?.trim() ? `${reason} ${asSentence(job.disabled_remedy)}` : reason;
 };
 
 /**

--- a/tests/contracts/project-run.node.ts
+++ b/tests/contracts/project-run.node.ts
@@ -564,9 +564,42 @@ test("a disabled job explains itself through the definition the route addresses"
   });
   const jobItem = items.find((item) => item.kind === "job");
 
-  expect(jobItem && runDefinitionUnavailability(jobItem, "1")).toBe("No assets");
+  expect(jobItem && runDefinitionUnavailability(jobItem, "1")).toBe("No assets.");
   expect(jobItem && runDefinitionUnavailability(jobItem, "2")).toBeUndefined();
   expect(runDefinitionUnavailability(items[0], workflowId)).toBeUndefined();
+});
+
+const disabledJobUnavailability = (overrides: Partial<JobSummary>) => {
+  const item = catalogue({ jobs: [job({ id: 1, disabled: true, ...overrides })] }).find(
+    (candidate) => candidate.kind === "job",
+  );
+
+  return item && runDefinitionUnavailability(item, "1");
+};
+
+test("a disabled job states the remedy the Data Manager offered with the reason", () => {
+  // The remedy is the fix offered alongside the problem, so it is stated with it rather than
+  // discarded, and each sentence the Data Manager wrote is ended so the two can be read together.
+  expect(
+    disabledJobUnavailability({
+      disabled_reason: "The job requires a licence that cannot be found",
+      disabled_remedy: "Buy a licence for this job",
+    }),
+  ).toBe("The job requires a licence that cannot be found. Buy a licence for this job.");
+  // A sentence the Data Manager already ended is not stopped twice.
+  expect(
+    disabledJobUnavailability({
+      disabled_reason: "No assets found.",
+      disabled_remedy: "Ask an administrator.",
+    }),
+  ).toBe("No assets found. Ask an administrator.");
+  // A remedy offered without a reason is still the only advice the caller has, so it survives the
+  // fallback that stands in for the missing reason.
+  expect(disabledJobUnavailability({ disabled_remedy: "Buy a licence" })).toBe(
+    "This job is disabled, so it cannot be run. Buy a licence.",
+  );
+  // A job disabled with neither is refused as it always was.
+  expect(disabledJobUnavailability({})).toBe("This job is disabled, so it cannot be run.");
 });
 
 test("a definition is placed by the catalogue that publishes its own type", () => {
@@ -667,7 +700,7 @@ test("emptying the type filter clears it rather than leaving a state no URL can 
 test("a definition answers for the exact version the route addresses", () => {
   const items = catalogue({
     jobs: [
-      job({ id: 1, disabled: true, disabled_reason: "No assets", version: "1.0.0" }),
+      job({ id: 1, disabled: true, disabled_reason: "No assets.", version: "1.0.0" }),
       job({ id: 2, version: "2.0.0" }),
     ],
   });
@@ -683,8 +716,8 @@ test("a definition answers for the exact version the route addresses", () => {
   // A card links to one version at a time, and the modal that link opens refuses a disabled version
   // with that version's own reason rather than the newest version's.
   expect(resolveFor(editor)?.("1")).toEqual({
-    availability: { status: "disabled", reason: "No assets" },
-    launch: { status: "disabled", reason: "No assets" },
+    availability: { status: "disabled", reason: "No assets." },
+    launch: { status: "disabled", reason: "No assets." },
   });
   expect(resolveFor(editor)?.("2")).toEqual({
     availability: { status: "enabled" },
@@ -693,7 +726,7 @@ test("a definition answers for the exact version the route addresses", () => {
   // A caller who also lacks authority is told what they lack first, but the version's own reason
   // is never replaced by it: both are stated, so nobody is left thinking the version is runnable.
   expect(resolveFor(observer)?.("1")).toEqual({
-    availability: { status: "disabled", reason: "No assets" },
+    availability: { status: "disabled", reason: "No assets." },
     launch: {
       status: "disabled",
       reason: "You must be a project editor or administrator to run work in this project.",


### PR DESCRIPTION
Closes #2016

The Data Manager supplies both a **reason** and a **remedy** when it disables a job. The remedy exists precisely for the reasons a caller can do something about — a missing licence being the documented case — and that is exactly where the UI said the least: `runDefinitionUnavailability` read `disabled_reason` alone and discarded `disabled_remedy`, so a caller was told the problem but not the fix offered alongside it.

## What changed

`src/projects/runFacts.ts` now states the remedy with the reason, as a second sentence in the same line. Both fields are free text and neither is promised to be punctuated, so a small `asSentence` helper ends each one before the two are read together — otherwise "No assets" and "Buy a licence" join into one run-on fragment beside the authority reason `CapabilityReasons` may also be printing. A sentence the Data Manager already ended is not stopped twice.

A remedy offered without a reason is appended to the existing fallback rather than dropped, and a job disabled with neither is refused exactly as before.

The combined string is built here rather than at render time, so `CapabilityReasons`' exact-string de-duplication still prints the shared reason once across `availability` and `launch`.

`required_assets` remains unused, as the issue scopes it out: the Data Manager already folds that case into `disabled_reason`.

## Tests

A new contract test in `tests/contracts/project-run.node.ts` covers reason + remedy, already-punctuated input, a remedy without a reason, and neither. Two existing tests asserted the unpunctuated `"No assets"` and now expect the terminated form — that is the intended behaviour change.

`pnpm tsc`, `pnpm lint` (`--max-warnings=0`) and `pnpm test` are all green: 238 acceptance and 830 contract/component tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)